### PR TITLE
✨ core: create AoS trait stores

### DIFF
--- a/benches/apps/boids/src/actions.ts
+++ b/benches/apps/boids/src/actions.ts
@@ -4,7 +4,7 @@ import * as THREE from 'three';
 
 export const useActions = createActions((world) => ({
 	spawnBoid: (position: THREE.Vector3, velocity: THREE.Vector3) => {
-		world.spawn(Position({ value: position }), Velocity({ value: velocity }), Neighbors, Forces);
+		world.spawn(Position(position), Velocity(velocity), Neighbors, Forces);
 	},
 	destroyAllBoids: () => {
 		world.query(Position, Velocity, Neighbors, Forces).forEach((entity) => {

--- a/benches/apps/boids/src/systems/apply-forces.ts
+++ b/benches/apps/boids/src/systems/apply-forces.ts
@@ -4,7 +4,7 @@ import { Forces, Time, Velocity } from '../traits';
 export const applyForces = ({ world }: { world: World }) => {
 	const { delta } = world.get(Time);
 
-	world.query(Forces, Velocity).updateEach(([forces, { value: velocity }]) => {
+	world.query(Forces, Velocity).updateEach(([forces, velocity]) => {
 		velocity.addScaledVector(forces.coherence, delta);
 		velocity.addScaledVector(forces.separation, delta);
 		velocity.addScaledVector(forces.alignment, delta);

--- a/benches/apps/boids/src/systems/avoid-edges.ts
+++ b/benches/apps/boids/src/systems/avoid-edges.ts
@@ -4,7 +4,7 @@ import { BoidsConfig, Forces, Position } from '../traits';
 export const avoidEdges = ({ world }: { world: World }) => {
 	const { avoidEdgesFactor, avoidEdgesMaxDistance } = world.get(BoidsConfig);
 
-	world.query(Forces, Position).updateEach(([{ avoidEdges }, { value: position }]) => {
+	world.query(Forces, Position).updateEach(([{ avoidEdges }, position]) => {
 		const distance = position.length();
 
 		if (distance > avoidEdgesMaxDistance) {

--- a/benches/apps/boids/src/systems/move-boids.ts
+++ b/benches/apps/boids/src/systems/move-boids.ts
@@ -5,7 +5,7 @@ export const moveBoids = ({ world }: { world: World }) => {
 	const { delta } = world.get(Time);
 	const { maxVelocity } = world.get(BoidsConfig);
 
-	world.query(Position, Velocity).updateEach(([{ value: position }, { value: velocity }]) => {
+	world.query(Position, Velocity).updateEach(([position, velocity]) => {
 		velocity.clampLength(0, maxVelocity);
 		position.addScaledVector(velocity, delta);
 	});

--- a/benches/apps/boids/src/systems/sync-three-object.ts
+++ b/benches/apps/boids/src/systems/sync-three-object.ts
@@ -11,7 +11,7 @@ export const syncThreeObjects = ({ world }: { world: World }) => {
 
 	const instancedMesh = instanceEntity.get(InstancedMesh)!.object;
 
-	world.query(Position).updateEach(([{ value: position }], entity) => {
+	world.query(Position).updateEach(([position], entity) => {
 		dummy.position.copy(position);
 		dummy.scale.set(0.5, 0.5, 0.5);
 		dummy.updateMatrix();

--- a/benches/apps/boids/src/systems/update-alignment.ts
+++ b/benches/apps/boids/src/systems/update-alignment.ts
@@ -4,13 +4,13 @@ import { BoidsConfig, Forces, Neighbors, Velocity } from '../traits';
 export const updateAlignment = ({ world }: { world: World }) => {
 	const { alignmentFactor } = world.get(BoidsConfig);
 
-	world.query(Forces, Neighbors).updateEach(([{ alignment }, { value: neighbors }]) => {
+	world.query(Forces, Neighbors).updateEach(([{ alignment }, neighbors]) => {
 		alignment.set(0, 0, 0);
 
 		if (neighbors.length === 0) return;
 
 		for (const neighbor of neighbors) {
-			alignment.add(neighbor.get(Velocity).value);
+			alignment.add(neighbor.get(Velocity));
 		}
 
 		alignment.divideScalar(neighbors.length).multiplyScalar(alignmentFactor);

--- a/benches/apps/boids/src/systems/update-coherence.ts
+++ b/benches/apps/boids/src/systems/update-coherence.ts
@@ -4,20 +4,18 @@ import { BoidsConfig, Forces, Neighbors, Position } from '../traits';
 export const updateCoherence = ({ world }: { world: World }) => {
 	const { coherenceFactor } = world.get(BoidsConfig);
 
-	world
-		.query(Forces, Neighbors, Position)
-		.updateEach(([forces, { value: neighbors }, { value: position }]) => {
-			const { coherence } = forces;
+	world.query(Forces, Neighbors, Position).updateEach(([forces, neighbors, position]) => {
+		const { coherence } = forces;
 
-			coherence.set(0, 0, 0);
+		coherence.set(0, 0, 0);
 
-			if (neighbors.length === 0) return;
+		if (neighbors.length === 0) return;
 
-			for (const neighbor of neighbors) {
-				coherence.add(neighbor.get(Position).value);
-			}
+		for (const neighbor of neighbors) {
+			coherence.add(neighbor.get(Position));
+		}
 
-			coherence.divideScalar(neighbors.length);
-			coherence.sub(position).multiplyScalar(coherenceFactor);
-		});
+		coherence.divideScalar(neighbors.length);
+		coherence.sub(position).multiplyScalar(coherenceFactor);
+	});
 };

--- a/benches/apps/boids/src/systems/update-neighbors.ts
+++ b/benches/apps/boids/src/systems/update-neighbors.ts
@@ -2,22 +2,20 @@ import { World } from 'koota';
 import { BoidsConfig, Neighbors, Position, SpatialHashMap } from '../traits';
 
 export const updateNeighbors = ({ world }: { world: World }) => {
-	const { value: spatialHashMap } = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap);
 	const { neighborSearchRadius } = world.get(BoidsConfig);
 
-	world
-		.query(Position, Neighbors)
-		.updateEach(([{ value: position }, { value: neighbors }], entity) => {
-			spatialHashMap.getNearbyEntities(
-				position.x,
-				position.y,
-				position.z,
-				neighborSearchRadius,
-				neighbors,
-				100
-			);
+	world.query(Position, Neighbors).updateEach(([position, neighbors], entity) => {
+		spatialHashMap.getNearbyEntities(
+			position.x,
+			position.y,
+			position.z,
+			neighborSearchRadius,
+			neighbors,
+			100
+		);
 
-			/* Remove entity itself from neighbors */
-			neighbors.splice(neighbors.indexOf(entity), 1);
-		});
+		/* Remove entity itself from neighbors */
+		neighbors.splice(neighbors.indexOf(entity), 1);
+	});
 };

--- a/benches/apps/boids/src/systems/update-separation.ts
+++ b/benches/apps/boids/src/systems/update-separation.ts
@@ -4,23 +4,21 @@ import { BoidsConfig, Forces, Neighbors, Position } from '../traits';
 export const updateSeparation = ({ world }: { world: World }) => {
 	const { separationFactor } = world.get(BoidsConfig);
 
-	world
-		.query(Forces, Neighbors, Position)
-		.updateEach(([{ separation }, { value: neighbors }, { value: position }]) => {
-			separation.set(0, 0, 0);
+	world.query(Forces, Neighbors, Position).updateEach(([{ separation }, neighbors, position]) => {
+		separation.set(0, 0, 0);
 
-			if (neighbors.length === 0) return;
+		if (neighbors.length === 0) return;
 
-			for (const neighbor of neighbors) {
-				const neighborPosition = neighbor.get(Position).value;
-				const distance = position.distanceTo(neighborPosition);
-				// Add a small epsilon to avoid division by zero
-				const safeDistance = Math.max(distance, 0.001);
-				const direction = position.clone().sub(neighborPosition).normalize();
-				// Inverse square law for separation
-				separation.add(direction.divideScalar(safeDistance * safeDistance));
-			}
+		for (const neighbor of neighbors) {
+			const neighborPosition = neighbor.get(Position);
+			const distance = position.distanceTo(neighborPosition);
+			// Add a small epsilon to avoid division by zero
+			const safeDistance = Math.max(distance, 0.001);
+			const direction = position.clone().sub(neighborPosition).normalize();
+			// Inverse square law for separation
+			separation.add(direction.divideScalar(safeDistance * safeDistance));
+		}
 
-			separation.divideScalar(neighbors.length).multiplyScalar(separationFactor);
-		});
+		separation.divideScalar(neighbors.length).multiplyScalar(separationFactor);
+	});
 };

--- a/benches/apps/boids/src/systems/update-spatial-hashing.ts
+++ b/benches/apps/boids/src/systems/update-spatial-hashing.ts
@@ -2,9 +2,9 @@ import { World } from 'koota';
 import { Position, SpatialHashMap } from '../traits';
 
 export const updateSpatialHashing = ({ world }: { world: World }) => {
-	const { value: spatialHashMap } = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap);
 
-	world.query(Position).updateEach(([{ value: position }], entity) => {
+	world.query(Position).updateEach(([position], entity) => {
 		spatialHashMap.setEntity(entity, position.x, position.y, position.z);
 	});
 };

--- a/benches/apps/boids/src/traits/neighbors.ts
+++ b/benches/apps/boids/src/traits/neighbors.ts
@@ -1,3 +1,3 @@
 import { Entity, trait } from 'koota';
 
-export const Neighbors = trait({ value: [] as Entity[] });
+export const Neighbors = trait(() => [] as Entity[]);

--- a/benches/apps/boids/src/traits/position.ts
+++ b/benches/apps/boids/src/traits/position.ts
@@ -1,4 +1,4 @@
 import { trait } from 'koota';
 import * as THREE from 'three';
 
-export const Position = trait({ value: () => new THREE.Vector3() });
+export const Position = trait(() => new THREE.Vector3());

--- a/benches/apps/boids/src/traits/spatial-hash-map.ts
+++ b/benches/apps/boids/src/traits/spatial-hash-map.ts
@@ -1,6 +1,4 @@
 import { trait } from 'koota';
 import { SpatialHashMap as SpatialHashMapImpl } from '../utils/spatial-hash';
 
-export const SpatialHashMap = trait({
-	value: () => new SpatialHashMapImpl(5),
-});
+export const SpatialHashMap = trait(() => new SpatialHashMapImpl(5));

--- a/benches/apps/boids/src/traits/velocity.ts
+++ b/benches/apps/boids/src/traits/velocity.ts
@@ -1,4 +1,8 @@
 import { trait } from 'koota';
 import * as THREE from 'three';
 
-export const Velocity = trait({ value: () => new THREE.Vector3() });
+export const Velocity = trait(() => {
+	const vel = new THREE.Vector3();
+	console.log(vel);
+	return vel;
+});

--- a/benches/apps/boids/src/world.ts
+++ b/benches/apps/boids/src/world.ts
@@ -1,10 +1,10 @@
 import { createWorld } from 'koota';
-import { SpatialHashMap, Time, BoidsConfig } from './traits';
+import { BoidsConfig, SpatialHashMap, Time } from './traits';
 import { SpatialHashMap as SpatialHashMapImpl } from './utils/spatial-hash';
 
 export const world = createWorld(
 	Time,
-	SpatialHashMap({ value: new SpatialHashMapImpl(5) }),
+	SpatialHashMap(new SpatialHashMapImpl(5)),
 	BoidsConfig({
 		count: 1000,
 		maxVelocity: 6,

--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -1,5 +1,11 @@
 import { Relation } from '../relation/types';
-import { ConfigurableTrait, Trait, TraitInstance } from '../trait/types';
+import {
+	ConfigurableTrait,
+	ExtractSchema,
+	ExtractTraitType,
+	Trait,
+	TraitInstance,
+} from '../trait/types';
 
 export type Entity = number & {
 	add: (...traits: ConfigurableTrait[]) => void;
@@ -7,8 +13,16 @@ export type Entity = number & {
 	has: (trait: Trait) => boolean;
 	destroy: () => void;
 	changed: (trait: Trait) => void;
-	set: <T extends Trait>(trait: T, value: Partial<TraitInstance<T>>, flagChanged?: boolean) => void;
-	get: <T extends Trait>(trait: T) => TraitInstance<T>;
+	set: <T extends Trait>(
+		trait: T,
+		value: ExtractTraitType<T> extends 'atomic'
+			? ReturnType<ExtractSchema<T>>
+			: Partial<TraitInstance<T>>,
+		flagChanged?: boolean
+	) => void;
+	get: <T extends Trait>(
+		trait: T
+	) => ExtractTraitType<T> extends 'atomic' ? ReturnType<ExtractSchema<T>> : TraitInstance<T>;
 	targetFor: <T>(relation: Relation<T>) => Entity | undefined;
 	targetsFor: <T>(relation: Relation<T>) => Entity[];
 	id: () => number;

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -79,7 +79,7 @@ export function createQueryResult<T extends QueryParameter[]>(
 						const ctx = trait[$internal];
 						const value = ctx.get(eid, stores[j]);
 						state[j] = value;
-						atomicSnapshots[j] = ctx.type === 'atomic' ? { ...value } : null;
+						atomicSnapshots[j] = ctx.type === 'aos' ? { ...value } : null;
 					}
 
 					callback(state as any, entity, i);
@@ -94,7 +94,7 @@ export function createQueryResult<T extends QueryParameter[]>(
 						const newValue = state[j];
 
 						let changed = false;
-						if (ctx.type === 'atomic') {
+						if (ctx.type === 'aos') {
 							changed = ctx.fastSetWithChangeDetection(eid, stores[j], newValue);
 							if (!changed) {
 								changed = !shallowEqual(newValue, atomicSnapshots[j]);

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -1,16 +1,17 @@
-import { getStore } from '../trait/trait';
-import { Trait, Store } from '../trait/types';
+import { $internal } from '../common';
 import { Entity } from '../entity/types';
 import { getEntityId } from '../entity/utils/pack-entity';
-import { $internal } from '../common';
+import { getStore } from '../trait/trait';
+import { Store, Trait } from '../trait/types';
+import { shallowEqual } from '../utils/shallow-equal';
 import { World } from '../world/world';
 import { ModifierData } from './modifier';
 import { Query } from './query';
 import {
+	InstancesFromParameters,
 	QueryParameter,
 	QueryResult,
 	QueryResultOptions,
-	SnapshotFromParameters,
 	StoresFromParameters,
 } from './types';
 
@@ -33,7 +34,7 @@ export function createQueryResult<T extends QueryParameter[]>(
 
 	const results = Object.assign(entities, {
 		updateEach(
-			callback: (state: SnapshotFromParameters<T>, entity: Entity, index: number) => void,
+			callback: (state: InstancesFromParameters<T>, entity: Entity, index: number) => void,
 			options?: QueryResultOptions
 		) {
 			const changeDetection = options?.changeDetection ?? false;
@@ -58,7 +59,6 @@ export function createQueryResult<T extends QueryParameter[]>(
 					if (!world.has(entity)) continue;
 
 					// Commit all changes back to the stores.
-					let changed = false;
 					for (let j = 0; j < traits.length; j++) {
 						const trait = traits[j];
 						const ctx = trait[$internal];
@@ -67,6 +67,7 @@ export function createQueryResult<T extends QueryParameter[]>(
 				}
 			} else {
 				const changedPairs: [Entity, Trait][] = [];
+				const atomicSnapshots: any[] = [];
 
 				for (let i = 0; i < entities.length; i++) {
 					const entity = entities[i];
@@ -76,7 +77,9 @@ export function createQueryResult<T extends QueryParameter[]>(
 					for (let j = 0; j < traits.length; j++) {
 						const trait = traits[j];
 						const ctx = trait[$internal];
-						state[j] = ctx.get(eid, stores[j]);
+						const value = ctx.get(eid, stores[j]);
+						state[j] = value;
+						atomicSnapshots[j] = ctx.type === 'atomic' ? { ...value } : null;
 					}
 
 					callback(state as any, entity, i);
@@ -85,11 +88,20 @@ export function createQueryResult<T extends QueryParameter[]>(
 					if (!world.has(entity)) continue;
 
 					// Commit all changes back to the stores.
-					let changed = false;
 					for (let j = 0; j < traits.length; j++) {
 						const trait = traits[j];
 						const ctx = trait[$internal];
-						changed = ctx.fastSetWithChangeDetection(eid, stores[j], state[j]);
+						const newValue = state[j];
+
+						let changed = false;
+						if (ctx.type === 'atomic') {
+							changed = ctx.fastSetWithChangeDetection(eid, stores[j], newValue);
+							if (!changed) {
+								changed = !shallowEqual(newValue, atomicSnapshots[j]);
+							}
+						} else {
+							changed = ctx.fastSetWithChangeDetection(eid, stores[j], newValue);
+						}
 
 						// Collect changed traits.
 						if (changed) changedPairs.push([entity, trait] as const);

--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -1,12 +1,5 @@
 import { Entity } from '../entity/types';
-import {
-	ExtractSchema,
-	ExtractStore,
-	ExtractTraitType,
-	IsTag,
-	Trait,
-	TraitInstance,
-} from '../trait/types';
+import { AoSFactory, ExtractSchema, ExtractStore, IsTag, Trait, TraitInstance } from '../trait/types';
 import { ModifierData } from './modifier';
 
 export type QueryModifier = (...components: Trait[]) => ModifierData;
@@ -48,7 +41,7 @@ export type InstancesFromParameters<T extends QueryParameter[]> = T extends [
 	? [
 			...(First extends Trait
 				? IsTag<First> extends false
-					? ExtractTraitType<First> extends 'atomic'
+					? ExtractSchema<First> extends AoSFactory
 						? [ReturnType<ExtractSchema<First>>]
 						: [TraitInstance<First>]
 					: []

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -2,28 +2,27 @@ import { Relation, RelationTarget } from '../relation/types';
 import { $internal } from '../common';
 import { IsEmpty } from '../utils/types';
 
-export type TraitType = 'atomic' | 'schematic';
+export type TraitType = 'aos' | 'soa';
+
+type TraitValue<TSchema extends Schema> = TSchema extends AoSFactory
+	? ReturnType<TSchema>
+	: Partial<TraitInstance<TSchema>>;
 
 export type Trait<
 	TSchema extends Schema = any,
 	TStore = Store<TSchema>,
-	TTag extends boolean = IsEmpty<TSchema>,
-	TType extends TraitType = TSchema extends AtomicFactory ? 'atomic' : 'schematic'
+	TTag extends boolean = IsEmpty<TSchema>
 > = {
 	schema: TSchema;
 	[$internal]: {
-		set: TSchema extends AtomicFactory
-			? (index: number, store: any, value: ReturnType<TSchema>) => void
-			: (index: number, store: any, value: Partial<TraitInstance<TSchema>>) => void;
-		fastSet: TSchema extends AtomicFactory
-			? (index: number, store: any, value: ReturnType<TSchema>) => void
-			: (index: number, store: any, value: Partial<TraitInstance<TSchema>>) => void;
-		fastSetWithChangeDetection: TSchema extends AtomicFactory
-			? (index: number, store: any, value: ReturnType<TSchema>) => boolean
-			: (index: number, store: any, value: Partial<TraitInstance<TSchema>>) => boolean;
-		get: TSchema extends AtomicFactory
-			? (index: number, store: any) => ReturnType<TSchema>
-			: (index: number, store: any) => TraitInstance<TSchema>;
+		set: (index: number, store: any, value: TraitValue<TSchema>) => void;
+		fastSet: (index: number, store: any, value: TraitValue<TSchema>) => boolean;
+		fastSetWithChangeDetection: (
+			index: number,
+			store: any,
+			value: TraitValue<TSchema>
+		) => boolean;
+		get: (index: number, store: any) => TraitValue<TSchema>;
 		stores: TStore[];
 		id: number;
 		createStore: () => TStore;
@@ -31,18 +30,14 @@ export type Trait<
 		relation: Relation<any> | null;
 		pairTarget: RelationTarget | null;
 		isTag: TTag;
-		type: TType;
+		type: TraitType;
 	};
-} & (TSchema extends AtomicFactory
-	? (params?: ReturnType<TSchema>) => [Trait<TSchema, TStore, TTag, TType>, ReturnType<TSchema>]
-	: (
-			params: Partial<TraitInstance<TSchema>>
-	  ) => [Trait<TSchema, TStore, TTag, TType>, Partial<TSchema>]);
+} & ((params?: TraitValue<TSchema>) => [Trait<TSchema, TStore, TTag>, TraitValue<TSchema>]);
 
 export type TraitTuple<T extends Trait = Trait> = [
 	T,
 	T extends Trait<infer S, any>
-		? S extends AtomicFactory
+		? S extends AoSFactory
 			? ReturnType<S>
 			: Partial<TraitInstance<S>>
 		: never
@@ -50,29 +45,33 @@ export type TraitTuple<T extends Trait = Trait> = [
 
 export type ConfigurableTrait<T extends Trait = Trait> = T | TraitTuple<T>;
 
-export type TraitInstance<T extends Trait | Schema> = T extends Trait
-	? T['schema'] extends AtomicFactory
-		? ReturnType<T['schema']>
-		: {
-				[P in keyof T['schema']]: T['schema'][P] extends (...args: any[]) => any
-					? ReturnType<T['schema'][P]>
-					: T['schema'][P];
-		  }
-	: T extends AtomicFactory
+type TraitInstanceFromTrait<T extends Trait> = T['schema'] extends AoSFactory
+	? ReturnType<T['schema']>
+	: {
+			[P in keyof T['schema']]: T['schema'][P] extends (...args: any[]) => any
+				? ReturnType<T['schema'][P]>
+				: T['schema'][P];
+	  };
+
+type TraitInstanceFromSchema<T extends Schema> = T extends AoSFactory
 	? ReturnType<T>
 	: {
 			[P in keyof T]: T[P] extends (...args: any[]) => any ? ReturnType<T[P]> : T[P];
 	  };
 
+export type TraitInstance<T extends Trait | Schema> = T extends Trait
+	? TraitInstanceFromTrait<T>
+	: TraitInstanceFromSchema<T>;
+
 export type Schema =
 	| {
 			[key: string]: number | string | boolean | any[] | object | null | undefined;
 	  }
-	| AtomicFactory;
+	| AoSFactory;
 
-export type AtomicFactory = () => Record<string, any>;
+export type AoSFactory = () => Record<string, any>;
 
-export type Store<T extends Schema = any> = T extends AtomicFactory
+export type Store<T extends Schema = any> = T extends AoSFactory
 	? ReturnType<T>[]
 	: {
 			[P in keyof T]: T[P] extends (...args: any[]) => any ? ReturnType<T[P]>[] : T[P][];
@@ -80,7 +79,7 @@ export type Store<T extends Schema = any> = T extends AtomicFactory
 
 // Utils
 
-export type Norm<T extends Schema> = T extends AtomicFactory
+export type Norm<T extends Schema> = T extends AoSFactory
 	? () => ReturnType<T> extends number
 			? number
 			: ReturnType<T> extends boolean
@@ -95,9 +94,6 @@ export type Norm<T extends Schema> = T extends AtomicFactory
 export type ExtractSchema<T extends Trait> = T extends Trait<infer S, any> ? S : never;
 export type ExtractStore<T extends Trait> = T extends Trait<any, infer S> ? S : never;
 export type ExtractIsTag<T extends Trait> = T extends Trait<any, any, infer Tag> ? Tag : false;
-export type ExtractTraitType<T extends Trait> = T extends Trait<any, any, any, infer Type>
-	? Type
-	: never;
 
 export type ExtractStores<T extends [Trait, ...Trait[]]> = T extends [infer C]
 	? C extends Trait<any, Store<any>>

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -2,21 +2,28 @@ import { Relation, RelationTarget } from '../relation/types';
 import { $internal } from '../common';
 import { IsEmpty } from '../utils/types';
 
+export type TraitType = 'atomic' | 'schematic';
+
 export type Trait<
 	TSchema extends Schema = any,
 	TStore = Store<TSchema>,
-	TTag extends boolean = IsEmpty<TSchema>
+	TTag extends boolean = IsEmpty<TSchema>,
+	TType extends TraitType = TSchema extends AtomicFactory ? 'atomic' : 'schematic'
 > = {
 	schema: TSchema;
 	[$internal]: {
-		set: (index: number, store: TStore, values: Partial<TraitInstance<TSchema>>) => void;
-		fastSet: (index: number, store: TStore, values: Partial<TraitInstance<TSchema>>) => void;
-		fastSetWithChangeDetection: (
-			index: number,
-			store: TStore,
-			values: Partial<TraitInstance<TSchema>>
-		) => boolean;
-		get: (index: number, store: TStore) => TraitInstance<TSchema>;
+		set: TSchema extends AtomicFactory
+			? (index: number, store: any, value: ReturnType<TSchema>) => void
+			: (index: number, store: any, value: Partial<TraitInstance<TSchema>>) => void;
+		fastSet: TSchema extends AtomicFactory
+			? (index: number, store: any, value: ReturnType<TSchema>) => void
+			: (index: number, store: any, value: Partial<TraitInstance<TSchema>>) => void;
+		fastSetWithChangeDetection: TSchema extends AtomicFactory
+			? (index: number, store: any, value: ReturnType<TSchema>) => boolean
+			: (index: number, store: any, value: Partial<TraitInstance<TSchema>>) => boolean;
+		get: TSchema extends AtomicFactory
+			? (index: number, store: any) => ReturnType<TSchema>
+			: (index: number, store: any) => TraitInstance<TSchema>;
 		stores: TStore[];
 		id: number;
 		createStore: () => TStore;
@@ -24,43 +31,73 @@ export type Trait<
 		relation: Relation<any> | null;
 		pairTarget: RelationTarget | null;
 		isTag: TTag;
+		type: TType;
 	};
-} & ((params: Partial<TraitInstance<TSchema>>) => [Trait<TSchema, TStore>, Partial<TSchema>]);
+} & (TSchema extends AtomicFactory
+	? (params?: ReturnType<TSchema>) => [Trait<TSchema, TStore, TTag, TType>, ReturnType<TSchema>]
+	: (
+			params: Partial<TraitInstance<TSchema>>
+	  ) => [Trait<TSchema, TStore, TTag, TType>, Partial<TSchema>]);
 
 export type TraitTuple<T extends Trait = Trait> = [
 	T,
-	T extends Trait<infer S, any> ? Partial<TraitInstance<S>> : never
+	T extends Trait<infer S, any>
+		? S extends AtomicFactory
+			? ReturnType<S>
+			: Partial<TraitInstance<S>>
+		: never
 ];
 
 export type ConfigurableTrait<T extends Trait = Trait> = T | TraitTuple<T>;
 
 export type TraitInstance<T extends Trait | Schema> = T extends Trait
-	? {
-			[P in keyof T['schema']]: T['schema'][P] extends (...args: any[]) => any
-				? ReturnType<T['schema'][P]>
-				: T['schema'][P];
-	  }
+	? T['schema'] extends AtomicFactory
+		? ReturnType<T['schema']>
+		: {
+				[P in keyof T['schema']]: T['schema'][P] extends (...args: any[]) => any
+					? ReturnType<T['schema'][P]>
+					: T['schema'][P];
+		  }
+	: T extends AtomicFactory
+	? ReturnType<T>
 	: {
 			[P in keyof T]: T[P] extends (...args: any[]) => any ? ReturnType<T[P]> : T[P];
 	  };
 
-export type Schema = {
-	[key: string]: number | string | boolean | any[] | object | null | undefined;
-};
+export type Schema =
+	| {
+			[key: string]: number | string | boolean | any[] | object | null | undefined;
+	  }
+	| AtomicFactory;
 
-export type Store<T extends Schema = any> = {
-	[P in keyof T]: T[P] extends (...args: any[]) => any ? ReturnType<T[P]>[] : T[P][];
-};
+export type AtomicFactory = () => Record<string, any>;
+
+export type Store<T extends Schema = any> = T extends AtomicFactory
+	? ReturnType<T>[]
+	: {
+			[P in keyof T]: T[P] extends (...args: any[]) => any ? ReturnType<T[P]>[] : T[P][];
+	  };
 
 // Utils
 
-export type Norm<T extends Schema> = {
-	[K in keyof T]: T[K] extends boolean ? boolean : T[K];
-};
+export type Norm<T extends Schema> = T extends AtomicFactory
+	? () => ReturnType<T> extends number
+			? number
+			: ReturnType<T> extends boolean
+			? boolean
+			: ReturnType<T> extends string
+			? string
+			: ReturnType<T>
+	: {
+			[K in keyof T]: T[K] extends boolean ? boolean : T[K];
+	  };
 
-export type TraitSnapshot<T extends Trait> = T extends Trait<infer S, any> ? TraitInstance<S> : never;
 export type ExtractSchema<T extends Trait> = T extends Trait<infer S, any> ? S : never;
 export type ExtractStore<T extends Trait> = T extends Trait<any, infer S> ? S : never;
+export type ExtractIsTag<T extends Trait> = T extends Trait<any, any, infer Tag> ? Tag : false;
+export type ExtractTraitType<T extends Trait> = T extends Trait<any, any, any, infer Type>
+	? Type
+	: never;
 
 export type ExtractStores<T extends [Trait, ...Trait[]]> = T extends [infer C]
 	? C extends Trait<any, Store<any>>

--- a/packages/core/src/trait/utils/create-accessors.ts
+++ b/packages/core/src/trait/utils/create-accessors.ts
@@ -1,6 +1,6 @@
 import { Schema } from '../types';
 
-export function createSetFunction(schema: Schema) {
+function createSoASetFunction(schema: Schema) {
 	const keys = Object.keys(schema);
 
 	// Generate a hardcoded set function based on the schema keys
@@ -21,7 +21,7 @@ export function createSetFunction(schema: Schema) {
 	return set;
 }
 
-export function createFastSetFunction(schema: Schema) {
+function createSoAFastSetFunction(schema: Schema) {
 	const keys = Object.keys(schema);
 
 	// Generate a hardcoded set function based on the schema keys
@@ -41,7 +41,7 @@ export function createFastSetFunction(schema: Schema) {
 }
 
 // Return true if any trait value were changed.
-export function createFastSetWithChangeDetectionFunction(schema: Schema) {
+function createSoAFastSetChangeFunction(schema: Schema) {
 	const keys = Object.keys(schema);
 
 	// Generate a hardcoded set function based on the schema keys
@@ -70,7 +70,7 @@ export function createFastSetWithChangeDetectionFunction(schema: Schema) {
 	return set;
 }
 
-export function createGetFunction(schema: Schema) {
+function createSoAGetFunction(schema: Schema) {
 	const keys = Object.keys(schema);
 
 	// Create an object literal with all keys assigned from the store
@@ -87,3 +87,44 @@ export function createGetFunction(schema: Schema) {
 
 	return get;
 }
+
+function createAoSSetFunction(_schema: Schema) {
+	return (index: number, store: any, value: any) => {
+		store[index] = value;
+	};
+}
+
+function createAoSFastSetChangeFunction(_schema: Schema) {
+	return (index: number, store: any, value: any) => {
+		let changed = false;
+		if (value !== store[index]) {
+			store[index] = value;
+			changed = true;
+		}
+		return changed;
+	};
+}
+
+function createAoSGetFunction(_schema: Schema) {
+	return (index: number, store: any) => store[index];
+}
+
+export const createSetFunction = {
+	soa: createSoASetFunction,
+	aos: createAoSSetFunction,
+};
+
+export const createFastSetFunction = {
+	soa: createSoAFastSetFunction,
+	aos: createAoSSetFunction,
+};
+
+export const createFastSetChangeFunction = {
+	soa: createSoAFastSetChangeFunction,
+	aos: createAoSFastSetChangeFunction,
+};
+
+export const createGetFunction = {
+	soa: createSoAGetFunction,
+	aos: createAoSGetFunction,
+};

--- a/packages/core/src/trait/utils/create-accessors.ts
+++ b/packages/core/src/trait/utils/create-accessors.ts
@@ -5,14 +5,14 @@ export function createSetFunction(schema: Schema) {
 
 	// Generate a hardcoded set function based on the schema keys
 	const setFunctionBody = keys
-		.map((key) => `if ('${key}' in values) store.${key}[index] = values.${key};`)
+		.map((key) => `if ('${key}' in value) store.${key}[index] = value.${key};`)
 		.join('\n    ');
 
 	// Use new Function to create a set function with hardcoded keys
 	const set = new Function(
 		'index',
 		'store',
-		'values',
+		'value',
 		`
 		${setFunctionBody}
 	  `
@@ -25,13 +25,13 @@ export function createFastSetFunction(schema: Schema) {
 	const keys = Object.keys(schema);
 
 	// Generate a hardcoded set function based on the schema keys
-	const setFunctionBody = keys.map((key) => `store.${key}[index] = values.${key};`).join('\n    ');
+	const setFunctionBody = keys.map((key) => `store.${key}[index] = value.${key};`).join('\n    ');
 
 	// Use new Function to create a set function with hardcoded keys
 	const set = new Function(
 		'index',
 		'store',
-		'values',
+		'value',
 		`
 		${setFunctionBody}
 	  `
@@ -40,7 +40,7 @@ export function createFastSetFunction(schema: Schema) {
 	return set;
 }
 
-// Return true if any trait values were changed.
+// Return true if any trait value were changed.
 export function createFastSetWithChangeDetectionFunction(schema: Schema) {
 	const keys = Object.keys(schema);
 
@@ -48,8 +48,8 @@ export function createFastSetWithChangeDetectionFunction(schema: Schema) {
 	const setFunctionBody = keys
 		.map(
 			(key) =>
-				`if (store.${key}[index] !== values.${key}) {
-            store.${key}[index] = values.${key};
+				`if (store.${key}[index] !== value.${key}) {
+            store.${key}[index] = value.${key};
             changed = true;
         }`
 		)
@@ -59,7 +59,7 @@ export function createFastSetWithChangeDetectionFunction(schema: Schema) {
 	const set = new Function(
 		'index',
 		'store',
-		'values',
+		'value',
 		`
         let changed = false;
         ${setFunctionBody}

--- a/packages/core/src/trait/utils/create-store.ts
+++ b/packages/core/src/trait/utils/create-store.ts
@@ -1,36 +1,40 @@
 import { Schema, Store } from '../types';
 
 export function createStore<T extends Schema>(schema: T): Store<T> {
-	const store = {} as any;
+	if (typeof schema === 'function') {
+		return [] as any;
+	} else {
+		const store = {} as any;
 
-	for (const key in schema) {
-		store[key] = [];
+		for (const key in schema) {
+			store[key] = [];
 
-		// Legacy code for TypedArray support -- MT in particular.
-		// I will revist this later.
+			// Legacy code for TypedArray support -- MT in particular.
+			// I will revist this later.
 
-		// if (isTypedArray(normalizedSchema[key])) {
-		// 	// Create a SharedArrayBuffer if supported, otherwise create an ArrayBuffer.
-		// 	const constructor =
-		// 		TypedArrayMap[normalizedSchema[key].type as keyof typeof TypedArrayMap];
-		// 	const byteLength = universe.getSize() * constructor.BYTES_PER_ELEMENT;
-		// 	const buffer = isSabSupported()
-		// 		? new SharedArrayBuffer(byteLength)
-		// 		: new ArrayBuffer(byteLength);
-		// 	store[key] = new constructor(buffer);
-		// 	// Resize the store if the world size changes
-		// 	universe.onResize((world, size) => {
-		// 		const newBuffer = isSabSupported()
-		// 			? new SharedArrayBuffer(size * constructor.BYTES_PER_ELEMENT)
-		// 			: new ArrayBuffer(size * constructor.BYTES_PER_ELEMENT);
-		// 		const newStore = new constructor(newBuffer);
-		// 		newStore.set(store[key]);
-		// 		store[key] = newStore;
-		// 	});
-		// } else {
-		// 	store[key] = [];
-		// }
+			// if (isTypedArray(normalizedSchema[key])) {
+			// 	// Create a SharedArrayBuffer if supported, otherwise create an ArrayBuffer.
+			// 	const constructor =
+			// 		TypedArrayMap[normalizedSchema[key].type as keyof typeof TypedArrayMap];
+			// 	const byteLength = universe.getSize() * constructor.BYTES_PER_ELEMENT;
+			// 	const buffer = isSabSupported()
+			// 		? new SharedArrayBuffer(byteLength)
+			// 		: new ArrayBuffer(byteLength);
+			// 	store[key] = new constructor(buffer);
+			// 	// Resize the store if the world size changes
+			// 	universe.onResize((world, size) => {
+			// 		const newBuffer = isSabSupported()
+			// 			? new SharedArrayBuffer(size * constructor.BYTES_PER_ELEMENT)
+			// 			: new ArrayBuffer(size * constructor.BYTES_PER_ELEMENT);
+			// 		const newStore = new constructor(newBuffer);
+			// 		newStore.set(store[key]);
+			// 		store[key] = newStore;
+			// 	});
+			// } else {
+			// 	store[key] = [];
+			// }
+		}
+
+		return store;
 	}
-
-	return store;
 }

--- a/packages/core/src/utils/shallow-equal.ts
+++ b/packages/core/src/utils/shallow-equal.ts
@@ -1,0 +1,24 @@
+export function shallowEqual(obj1: any, obj2: any): boolean {
+	if (obj1 === obj2) {
+		return true;
+	}
+
+	if (typeof obj1 !== 'object' || obj1 === null || typeof obj2 !== 'object' || obj2 === null) {
+		return false;
+	}
+
+	const keys1 = Object.keys(obj1);
+	const keys2 = Object.keys(obj2);
+
+	if (keys1.length !== keys2.length) {
+		return false;
+	}
+
+	for (const key of keys1) {
+		if (!obj2.hasOwnProperty(key) || obj1[key] !== obj2[key]) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -95,7 +95,7 @@ export class World {
 		this[$internal].worldEntity.remove(...traits);
 	}
 
-	get<T extends Trait>(trait: T): TraitInstance<T> {
+	get<T extends Trait>(trait: T) {
 		return this[$internal].worldEntity.get(trait);
 	}
 

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -679,4 +679,45 @@ describe('Query', () => {
 			expect(name.name).toBeDefined();
 		});
 	});
+
+	it('updateEach works with atomic traits', () => {
+		const Position = trait(() => ({ x: 0, y: 0 }));
+		const Mass = trait(() => ({ value: 0 }));
+
+		const entity = world.spawn(Position, Mass);
+		world.query(Position, Mass).updateEach(([position, mass]) => {
+			position.x = 1;
+			mass.value = 10;
+		});
+
+		expect(entity.get(Position).x).toBe(1);
+		expect(entity.get(Mass).value).toBe(10);
+	});
+
+	it('updateEach works with atomic traits and change detection', () => {
+		const Position = trait(() => ({ x: 0, y: 0 }));
+		const cb = vi.fn();
+		world.onChange(Position, cb);
+		world.spawn(Position);
+
+		expect(cb).toHaveBeenCalledTimes(0);
+
+		world.query(Position).updateEach(
+			([position]) => {
+				position.x = 0;
+			},
+			{ changeDetection: true }
+		);
+
+		expect(cb).toHaveBeenCalledTimes(0);
+
+		world.query(Position).updateEach(
+			([position]) => {
+				position.x = 1;
+			},
+			{ changeDetection: true }
+		);
+
+		expect(cb).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cacheQuery, createWorld } from '../src';
-import { trait, getStores } from '../src/trait/trait';
+import { $internal } from '../src/common';
 import { createAdded } from '../src/query/modifiers/added';
 import { createChanged } from '../src/query/modifiers/changed';
 import { Not } from '../src/query/modifiers/not';
-import { createRemoved } from '../src/query/modifiers/removed';
-import { $internal } from '../src/common';
-import { IsExcluded } from '../src/query/query';
 import { Or } from '../src/query/modifiers/or';
+import { createRemoved } from '../src/query/modifiers/removed';
+import { IsExcluded } from '../src/query/query';
+import { getStores, trait } from '../src/trait/trait';
 
 const Position = trait({ x: 0, y: 0 });
 const Name = trait({ name: 'name' });

--- a/packages/core/tests/trait.test.ts
+++ b/packages/core/tests/trait.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createWorld } from '../src';
-import { trait, getStores, registerTrait } from '../src/trait/trait';
+import { createWorld, Entity } from '../src';
 import { $internal } from '../src/common';
+import { getStores, registerTrait, trait } from '../src/trait/trait';
 
 class TestClass {
 	constructor(public name = 'TestClass') {}
@@ -194,5 +194,32 @@ describe('Trait', () => {
 		const entityB = world.spawn(Test);
 		expect(mock).toHaveBeenCalledTimes(2);
 		expect(entityB.get(Test).value).toBeInstanceOf(TestClass);
+	});
+
+	it('can create atomic traits', () => {
+		let object = { a: 1, b: 2 };
+		const AtomicObject = trait(() => object);
+		let entity = world.spawn(AtomicObject);
+
+		// The object is returned by reference.
+		expect(object).toBe(entity.get(AtomicObject));
+		expect(entity.get(AtomicObject).a).toBe(1);
+
+		entity.set(AtomicObject, { a: 2, b: 3 });
+
+		// A new object is set making the reference different.
+		expect(object).not.toBe(entity.get(AtomicObject));
+		expect(entity.get(AtomicObject).a).toBe(2);
+
+		// Can pass in a custom object into the trait.
+		entity = world.spawn(AtomicObject({ a: 3, b: 4 }));
+		expect(entity.get(AtomicObject).a).toBe(3);
+		// Works with arrays too.
+		const AtomicArray = trait(() => [1, 2, 3]);
+		entity = world.spawn(AtomicArray);
+		expect(entity.get(AtomicArray)).toEqual([1, 2, 3]);
+
+		entity.set(AtomicArray, [4, 5, 6]);
+		expect(entity.get(AtomicArray)).toEqual([4, 5, 6]);
 	});
 });


### PR DESCRIPTION
This PR enables creating AoS trait stores using callbacks.
```js
// AoS store
const Position = trait(() => ({ x: 0, y: 0, z: 0 }))

// SoA store
const Position = trait({ x: 0, y: 0, z: 0 })
```
While SoA stores are recommended for performance, AoS is very useful for compatibility with libraries and class instances in general.
```js
const Position = trait(() => THREE.Vector3())
```
I banged out the code to make it work but it needs refactoring with fresh eyes before it goes into production.