### PR TITLE
🐛 react: useQuery propertly updates, returns a QueryResult

### DIFF
--- a/packages/react/src/hooks/use-query.ts
+++ b/packages/react/src/hooks/use-query.ts
@@ -1,18 +1,34 @@
+import { QueryParameter, QueryResult } from '@koota/core';
 import { useEffect, useState } from 'react';
 import { useWorld } from '../world/use-world';
-import { Entity, QueryParameter } from '@koota/core';
 
-export function useQuery(...parameters: QueryParameter[]) {
+export function useQuery<T extends QueryParameter[]>(...parameters: T) {
 	const world = useWorld();
-	const [entities, setEntities] = useState<Entity[]>([]);
+	const [entities, setEntities] = useState<QueryResult<T>>(world.query(...parameters));
 
 	useEffect(() => {
 		const unsubAdd = world.onAdd(parameters, (entity) => {
-			setEntities((v) => [...v, entity]);
+			setEntities((v) => {
+				// @ts-expect-error - QueryResult is a readonly array, but we need to mutate it
+				v.push(entity);
+				return v;
+			});
 		});
 
 		const unsubRemove = world.onRemove(parameters, (entity) => {
-			setEntities((v) => v.filter((e) => e !== entity));
+			setEntities((v) => {
+				// Remove the entity from the array by moving and popping it
+				const index = v.indexOf(entity);
+				// Move the last element to the index of the removed element
+				// @ts-expect-error - QueryResult is a readonly array, but we need to mutate it
+				v[index] = v[v.length - 1];
+				// Pop the last element
+				// @ts-expect-error - QueryResult is a readonly array, but we need to mutate it
+				v.pop();
+
+				console.log(entity, v);
+				return v;
+			});
 		});
 
 		return () => {

--- a/packages/react/tests/hooks.test.tsx
+++ b/packages/react/tests/hooks.test.tsx
@@ -1,4 +1,4 @@
-import { createWorld, Entity, trait, TraitInstance, universe, World } from '@koota/core';
+import { createWorld, Entity, QueryResult, trait, TraitInstance, universe, World } from '@koota/core';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
 import { act, StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -61,7 +61,11 @@ describe('Hooks', () => {
 	});
 
 	it('useQuery', async () => {
-		let entities: number[] = [];
+		let entities: QueryResult<[typeof Position]> = null!;
+
+		let entityA: Entity;
+		let entityB: Entity;
+		let entityC: Entity;
 
 		function Test() {
 			entities = useQuery(Position);
@@ -71,6 +75,8 @@ describe('Hooks', () => {
 		let renderer: any;
 
 		await act(async () => {
+			entityA = world.spawn(Position);
+
 			renderer = await ReactThreeTestRenderer.create(
 				<StrictMode>
 					<WorldProvider world={world}>
@@ -80,14 +86,11 @@ describe('Hooks', () => {
 			);
 		});
 
-		expect(entities.length).toBe(0);
-
-		let entityA: Entity;
-		let entityB: Entity;
+		expect(entities.length).toBe(1);
 
 		await act(async () => {
-			entityA = world.spawn(Position);
 			entityB = world.spawn(Position);
+			entityC = world.spawn(Position);
 			world.spawn(Position);
 
 			await renderer!.update(
@@ -99,11 +102,12 @@ describe('Hooks', () => {
 			);
 		});
 
-		expect(entities.length).toBe(3);
+		expect(entities.length).toBe(4);
 
 		await act(async () => {
 			entityA.destroy();
 			entityB.destroy();
+			entityC.destroy();
 
 			await renderer!.update(
 				<StrictMode>


### PR DESCRIPTION
Note that `useQuery` returns the same `QueryResult` every time, but updates its entities as additions and removals happen.