### PR TITLE
✨ core: entity set can take a callback with previous state passed in

### DIFF
--- a/packages/core/src/entity/entity-methods-patch.ts
+++ b/packages/core/src/entity/entity-methods-patch.ts
@@ -64,6 +64,11 @@ Number.prototype.set = function (this: Entity, trait: Trait, value: any, trigger
 	const index = this & ENTITY_ID_MASK;
 	const worldId = this >>> WORLD_ID_SHIFT;
 	const store = ctx.stores[worldId];
+
+	if (typeof value === 'function') {
+		value = value(ctx.get(index, store));
+	}
+
 	ctx.set(index, store, value);
 	triggerChanged && setChanged(universe.worlds[worldId], this, trait);
 };

--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -9,7 +9,9 @@ export type Entity = number & {
 	changed: (trait: Trait) => void;
 	set: <T extends Trait>(
 		trait: T,
-		value: TraitValue<ExtractSchema<T>>,
+		value:
+			| TraitValue<ExtractSchema<T>>
+			| ((prev: TraitInstance<ExtractSchema<T>>) => TraitValue<ExtractSchema<T>>),
 		flagChanged?: boolean
 	) => void;
 	get: <T extends Trait>(trait: T) => TraitInstance<ExtractSchema<T>>;

--- a/packages/core/tests/entity.test.ts
+++ b/packages/core/tests/entity.test.ts
@@ -123,6 +123,12 @@ describe('Entity', () => {
 		expect(entity.get(Bar).value).toBe(1);
 	});
 
+	it('can set trait state with a callback', () => {
+		const entity = world.spawn(Bar);
+		entity.set(Bar, (prev) => ({ value: prev.value + 1 }));
+		expect(entity.get(Bar).value).toBe(1);
+	});
+
 	it('should trigger change events when trait state is set', () => {
 		const entity = world.spawn(Bar);
 		let called = false;


### PR DESCRIPTION
Signed-off-by: Kris Baumgartner <kjbaumgartner@gmail.com>