### PR TITLE
fix: Wildcard relation is a valid RelationTarget.

### DIFF
--- a/packages/core/src/entity/entity.ts
+++ b/packages/core/src/entity/entity.ts
@@ -62,7 +62,7 @@ export function destroyEntity(world: World, entity: Entity) {
 					const traitCtx = trait[$internal];
 					if (!traitCtx.isPairTrait) continue;
 
-					const relationCtx = traitCtx.relation[$internal];
+					const relationCtx = traitCtx.relation![$internal];
 
 					// Remove wildcard pair trait.
 					removeTrait(world, subject, Pair(Wildcard, currentEntity));

--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -15,7 +15,7 @@ export type Entity = number & {
 		flagChanged?: boolean
 	) => void;
 	get: <T extends Trait>(trait: T) => TraitInstance<ExtractSchema<T>>;
-	targetFor: <T>(relation: Relation<T>) => Entity | undefined;
-	targetsFor: <T>(relation: Relation<T>) => Entity[];
+	targetFor: <T extends Trait>(relation: Relation<T>) => Entity | undefined;
+	targetsFor: <T extends Trait>(relation: Relation<T>) => Entity[];
 	id: () => number;
 };

--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -1,4 +1,3 @@
-import { TraitData } from '../../trait/trait-data';
 import { Trait } from '../../trait/types';
 import { Entity } from '../../entity/types';
 import { universe } from '../../universe/universe';

--- a/packages/core/src/relation/relation.ts
+++ b/packages/core/src/relation/relation.ts
@@ -2,7 +2,7 @@ import { trait } from '../trait/trait';
 import { Trait, Schema } from '../trait/types';
 import { $internal } from '../common';
 import { World } from '../world/world';
-import { Relation, RelationTarget } from './types';
+import { Relation, RelationTarget, WildcardRelation } from './types';
 
 function defineRelation<S extends Schema = any, T extends Trait = Trait<Schema>>(definition?: {
 	exclusive?: boolean;
@@ -67,7 +67,7 @@ export const getRelationTargets = (world: World, relation: Relation<any>, entity
 export const Pair = <T extends Trait>(relation: Relation<T>, target: RelationTarget): T => {
 	if (relation === undefined) throw Error('Relation is undefined');
 	if (target === undefined) throw Error('Relation target is undefined');
-	if (target === '*') target = Wildcard as RelationTarget;
+	if (target === '*') target = Wildcard;
 
 	const ctx = relation[$internal];
 	const pairsMap = ctx.pairsMap;
@@ -76,4 +76,7 @@ export const Pair = <T extends Trait>(relation: Relation<T>, target: RelationTar
 	return getRelationTrait<T>(relation, traitFactory, pairsMap, target);
 };
 
-export const Wildcard: Relation<any> | string = defineRelation();
+const _Wildcard = defineRelation() as WildcardRelation;
+_Wildcard[$internal].wildcard = true;
+
+export const Wildcard: WildcardRelation = _Wildcard;

--- a/packages/core/src/relation/types.ts
+++ b/packages/core/src/relation/types.ts
@@ -1,7 +1,7 @@
 import { $internal } from '../common';
 import { Trait } from '../trait/types';
 
-export type RelationTarget = number | string;
+export type RelationTarget = number | string | WildcardRelation;
 
 export type Relation<T extends Trait> = {
 	[$internal]: {
@@ -11,3 +11,14 @@ export type Relation<T extends Trait> = {
 		autoRemoveTarget: boolean;
 	};
 } & ((target: RelationTarget) => T);
+
+export type WildcardRelation = {
+	[$internal]: {
+		/** Used to differentiate between wildcard and normal relations on the type level */
+		wildcard: true;
+		pairsMap: Map<number | string, Trait>;
+		createTrait: () => Trait;
+		exclusive: boolean;
+		autoRemoveTarget: boolean;
+	};
+} & ((target: RelationTarget) => Trait);

--- a/packages/core/tests/relation.test.ts
+++ b/packages/core/tests/relation.test.ts
@@ -151,4 +151,23 @@ describe('Relation', () => {
 		expect(relatesToGold).toContain(dwarf);
 		expect(relatesToGold).toContain(dragon);
 	});
+
+	it('should query a specific relation targeting an entity', () => {
+		const ChildOf = relation();
+
+		const root = world.spawn();
+		const child1 = world.spawn(ChildOf(root));
+		const child2 = world.spawn(ChildOf(root));
+		const leaf = world.spawn(ChildOf(child2));
+
+		const childrenOfRoot = world.query(ChildOf(root));
+		const childrenOfChild2 = world.query(ChildOf(child2));
+
+		expect(childrenOfRoot.length).toBe(2);
+		expect(childrenOfRoot).toContain(child1);
+		expect(childrenOfRoot).toContain(child2);
+
+		expect(childrenOfChild2.length).toBe(1);
+		expect(childrenOfChild2).toContain(leaf);
+	});
 });


### PR DESCRIPTION
Hi! 👋 
Was trying to fix a different issue, but it seems that it was already resolved. Meanwhile, I found a possible solution to the incompatible type of `Wildcard` in some scenarios.

### Changes
- `Wildcard` is both an acceptable `RelationTarget` as well as a callable, which is hard to achieve with the current `Relation<any> | string` type.
- `RelationTarget` is not broad enough to accept any Relation, as `Wildcard` differs on the type-level, yet is assignable to any `Relation` (see screenshot below).
- An additional test for querying relations with specific targets.

<img width="840" alt="Screenshot 2025-01-01 at 18 02 18" src="https://github.com/user-attachments/assets/c063d718-a5af-431f-ae16-5d78f3cb4b8e" />
