### PR TITLE
🐛 core: `entity.get` always returns `undefined` for missing trait.

### DIFF
--- a/benches/apps/add-remove/src/systems/syncThreeObjects.ts
+++ b/benches/apps/add-remove/src/systems/syncThreeObjects.ts
@@ -12,7 +12,7 @@ export const syncThreeObjects = ({ world }: { world: World }) => {
 	const particlesEntity = world.queryFirst(Points);
 	if (!particlesEntity) return;
 
-	const particles = particlesEntity.get(Points).object;
+	const particles = particlesEntity.get(Points)!.object;
 
 	const positions = particles.geometry.attributes.position.array;
 	const colors = particles.geometry.attributes.color.array;

--- a/benches/apps/boids/src/app.tsx
+++ b/benches/apps/boids/src/app.tsx
@@ -17,7 +17,7 @@ export function App() {
 	const { spawnBoid, destroyAllBoids } = useActions(actions);
 
 	useLayoutEffect(() => {
-		const { initialCount: count } = world.get(BoidsConfig);
+		const { initialCount: count } = world.get(BoidsConfig)!;
 
 		for (let i = 0; i < count; i++) {
 			const position = new THREE.Vector3().randomDirection().multiplyScalar(between(0, 10));

--- a/benches/apps/boids/src/systems/apply-forces.ts
+++ b/benches/apps/boids/src/systems/apply-forces.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Forces, Time, Velocity } from '../traits';
 
 export const applyForces = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 
 	world.query(Forces, Velocity).updateEach(([forces, velocity]) => {
 		velocity.addScaledVector(forces.coherence, delta);

--- a/benches/apps/boids/src/systems/avoid-edges.ts
+++ b/benches/apps/boids/src/systems/avoid-edges.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { BoidsConfig, Forces, Position } from '../traits';
 
 export const avoidEdges = ({ world }: { world: World }) => {
-	const { avoidEdgesFactor, avoidEdgesMaxDistance } = world.get(BoidsConfig);
+	const { avoidEdgesFactor, avoidEdgesMaxDistance } = world.get(BoidsConfig)!;
 
 	world.query(Forces, Position).updateEach(([{ avoidEdges }, position]) => {
 		const distance = position.length();

--- a/benches/apps/boids/src/systems/move-boids.ts
+++ b/benches/apps/boids/src/systems/move-boids.ts
@@ -2,8 +2,8 @@ import { World } from 'koota';
 import { BoidsConfig, Position, Time, Velocity } from '../traits';
 
 export const moveBoids = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
-	const { maxVelocity } = world.get(BoidsConfig);
+	const { delta } = world.get(Time)!;
+	const { maxVelocity } = world.get(BoidsConfig)!;
 
 	world.query(Position, Velocity).updateEach(([position, velocity]) => {
 		velocity.clampLength(0, maxVelocity);

--- a/benches/apps/boids/src/systems/update-alignment.ts
+++ b/benches/apps/boids/src/systems/update-alignment.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { BoidsConfig, Forces, Neighbors, Velocity } from '../traits';
 
 export const updateAlignment = ({ world }: { world: World }) => {
-	const { alignmentFactor } = world.get(BoidsConfig);
+	const { alignmentFactor } = world.get(BoidsConfig)!;
 
 	world.query(Forces, Neighbors).updateEach(([{ alignment }, neighbors]) => {
 		alignment.set(0, 0, 0);
@@ -10,7 +10,7 @@ export const updateAlignment = ({ world }: { world: World }) => {
 		if (neighbors.length === 0) return;
 
 		for (const neighbor of neighbors) {
-			alignment.add(neighbor.get(Velocity));
+			alignment.add(neighbor.get(Velocity)!);
 		}
 
 		alignment.divideScalar(neighbors.length).multiplyScalar(alignmentFactor);

--- a/benches/apps/boids/src/systems/update-coherence.ts
+++ b/benches/apps/boids/src/systems/update-coherence.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { BoidsConfig, Forces, Neighbors, Position } from '../traits';
 
 export const updateCoherence = ({ world }: { world: World }) => {
-	const { coherenceFactor } = world.get(BoidsConfig);
+	const { coherenceFactor } = world.get(BoidsConfig)!;
 
 	world.query(Forces, Neighbors, Position).updateEach(([forces, neighbors, position]) => {
 		const { coherence } = forces;
@@ -12,7 +12,7 @@ export const updateCoherence = ({ world }: { world: World }) => {
 		if (neighbors.length === 0) return;
 
 		for (const neighbor of neighbors) {
-			coherence.add(neighbor.get(Position));
+			coherence.add(neighbor.get(Position)!);
 		}
 
 		coherence.divideScalar(neighbors.length);

--- a/benches/apps/boids/src/systems/update-neighbors.ts
+++ b/benches/apps/boids/src/systems/update-neighbors.ts
@@ -2,8 +2,8 @@ import { World } from 'koota';
 import { BoidsConfig, Neighbors, Position, SpatialHashMap } from '../traits';
 
 export const updateNeighbors = ({ world }: { world: World }) => {
-	const spatialHashMap = world.get(SpatialHashMap);
-	const { neighborSearchRadius } = world.get(BoidsConfig);
+	const spatialHashMap = world.get(SpatialHashMap)!;
+	const { neighborSearchRadius } = world.get(BoidsConfig)!;
 
 	world.query(Position, Neighbors).updateEach(([position, neighbors], entity) => {
 		spatialHashMap.getNearbyEntities(

--- a/benches/apps/boids/src/systems/update-separation.ts
+++ b/benches/apps/boids/src/systems/update-separation.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { BoidsConfig, Forces, Neighbors, Position } from '../traits';
 
 export const updateSeparation = ({ world }: { world: World }) => {
-	const { separationFactor } = world.get(BoidsConfig);
+	const { separationFactor } = world.get(BoidsConfig)!;
 
 	world.query(Forces, Neighbors, Position).updateEach(([{ separation }, neighbors, position]) => {
 		separation.set(0, 0, 0);
@@ -10,7 +10,7 @@ export const updateSeparation = ({ world }: { world: World }) => {
 		if (neighbors.length === 0) return;
 
 		for (const neighbor of neighbors) {
-			const neighborPosition = neighbor.get(Position);
+			const neighborPosition = neighbor.get(Position)!;
 			const distance = position.distanceTo(neighborPosition);
 			// Add a small epsilon to avoid division by zero
 			const safeDistance = Math.max(distance, 0.001);

--- a/benches/apps/boids/src/systems/update-spatial-hashing.ts
+++ b/benches/apps/boids/src/systems/update-spatial-hashing.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Position, SpatialHashMap } from '../traits';
 
 export const updateSpatialHashing = ({ world }: { world: World }) => {
-	const spatialHashMap = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap)!;
 
 	world.query(Position).updateEach(([position], entity) => {
 		spatialHashMap.setEntity(entity, position.x, position.y, position.z);

--- a/benches/apps/boids/src/systems/update-time.ts
+++ b/benches/apps/boids/src/systems/update-time.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Time } from '../traits/time';
 
 export const updateTime = ({ world }: { world: World }) => {
-	const time = world.get(Time);
+	const time = world.get(Time)!;
 
 	if (time.then === 0) time.then = performance.now();
 

--- a/benches/apps/n-body/src/systems/render.ts
+++ b/benches/apps/n-body/src/systems/render.ts
@@ -2,6 +2,6 @@ import { World } from 'koota';
 import { Three } from '../main';
 
 export const render = ({ world }: { world: World }) => {
-	const { renderer, scene, camera } = world.get(Three);
+	const { renderer, scene, camera } = world.get(Three)!;
 	renderer.render(scene, camera);
 };

--- a/benches/apps/revade/src/app.tsx
+++ b/benches/apps/revade/src/app.tsx
@@ -199,16 +199,16 @@ function Explosions() {
 
 function ExplosionRenderer({ entity }: { entity: Entity }) {
 	const groupRef = useRef<THREE.Group>(null);
-	const particleCount = entity.get(Explosion).count;
+	const particleCount = entity.get(Explosion)!.count;
 
 	useLayoutEffect(() => {
 		if (!groupRef.current) return;
 
 		// Position the explosion group
-		groupRef.current.position.copy(entity.get(Transform).position);
+		groupRef.current.position.copy(entity.get(Transform)!.position);
 
 		// Set particle velocities with random offset
-		const velocities = entity.get(Explosion).velocities;
+		const velocities = entity.get(Explosion)!.velocities;
 		const randomOffset = Math.random() * Math.PI * 2; // Random starting angle
 
 		for (let i = 0; i < particleCount; i++) {
@@ -224,10 +224,10 @@ function ExplosionRenderer({ entity }: { entity: Entity }) {
 	useFrame((_, delta) => {
 		if (!groupRef.current) return;
 
-		const { duration, current } = entity.get(Explosion);
+		const { duration, current } = entity.get(Explosion)!;
 		const progress = current / duration;
 
-		const velocities = entity.get(Explosion).velocities;
+		const velocities = entity.get(Explosion)!.velocities;
 		const particles = groupRef.current.children as THREE.Mesh[];
 
 		for (let i = 0; i < particleCount; i++) {
@@ -275,7 +275,7 @@ const BulletRenderer = memo(({ entity }: { entity: Entity }) => {
 		if (!meshRef.current) return;
 
 		// Copy current values
-		const { position, rotation, quaternion } = entity.get(Transform);
+		const { position, rotation, quaternion } = entity.get(Transform)!;
 		meshRef.current.position.copy(position);
 		meshRef.current.rotation.copy(rotation);
 		meshRef.current.quaternion.copy(quaternion);

--- a/benches/apps/revade/src/systems/apply-input.ts
+++ b/benches/apps/revade/src/systems/apply-input.ts
@@ -6,7 +6,7 @@ const UP = new THREE.Vector3(0, 1, 0);
 const tmpvec3 = new THREE.Vector3();
 
 export const applyInput = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 	world
 		.query(IsPlayer, Input, Transform, Movement)
 		.updateEach(([input, transform, { velocity, thrust }]) => {

--- a/benches/apps/revade/src/systems/cleanup-spatial-hash-map.ts
+++ b/benches/apps/revade/src/systems/cleanup-spatial-hash-map.ts
@@ -4,7 +4,7 @@ import { SpatialHashMap, Transform } from '../traits';
 const Removed = createRemoved();
 
 export const cleanupSpatialHashMap = ({ world }: { world: World }) => {
-	const spatialHashMap = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap)!;
 	world.query(Removed(Transform)).forEach((entity) => {
 		spatialHashMap.removeEntity(entity);
 	});

--- a/benches/apps/revade/src/systems/follow-player.ts
+++ b/benches/apps/revade/src/systems/follow-player.ts
@@ -9,7 +9,7 @@ export const followPlayer = ({ world }: { world: World }) => {
 	const player = world.queryFirst(IsPlayer, Transform);
 	if (!player) return;
 
-	const playerTransform = player.get(Transform);
+	const playerTransform = player.get(Transform)!;
 
 	world
 		.query(IsEnemy, Transform, Movement)

--- a/benches/apps/revade/src/systems/handle-shooting.ts
+++ b/benches/apps/revade/src/systems/handle-shooting.ts
@@ -24,7 +24,7 @@ window.addEventListener('keyup', (e) => {
 });
 
 export const handleShooting = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 	const { spawnBullet } = actions(world);
 
 	// Update cooldown
@@ -40,7 +40,7 @@ export const handleShooting = ({ world }: { world: World }) => {
 	if (keys.space && canShoot) {
 		const player = world.queryFirst(IsPlayer, Transform);
 		if (player) {
-			const playerTransform = player.get(Transform);
+			const playerTransform = player.get(Transform)!;
 			spawnBullet(playerTransform.position, playerTransform.quaternion);
 			canShoot = false;
 		}

--- a/benches/apps/revade/src/systems/push-enemies.ts
+++ b/benches/apps/revade/src/systems/push-enemies.ts
@@ -7,7 +7,7 @@ const pushStrength = 0.1;
 const pushForce = new THREE.Vector3();
 
 export const pushEnemies = ({ world }: { world: World }) => {
-	const spatialHashMap = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap)!;
 
 	world.query(IsPlayer, Transform, Movement).updateEach(([{ position }, { velocity }], player) => {
 		// Get nearby entities
@@ -22,14 +22,14 @@ export const pushEnemies = ({ world }: { world: World }) => {
 		const collidingEnemies: Entity[] = nearbyEntities.filter((entity) => {
 			return (
 				entity.has(IsEnemy) &&
-				entity.get(Transform).position.distanceTo(position) <= collisionRadius
+				entity.get(Transform)!.position.distanceTo(position) <= collisionRadius
 			);
 		});
 
 		// Apply push force to colliding enemies
 		for (const enemy of collidingEnemies) {
-			const enemyTransform = enemy.get(Transform);
-			const enemyMovement = enemy.get(Movement);
+			const enemyTransform = enemy.get(Transform)!;
+			const enemyMovement = enemy.get(Movement)!;
 
 			// Calculate push direction (away from player)
 			pushForce

--- a/benches/apps/revade/src/systems/spawn-enemies.ts
+++ b/benches/apps/revade/src/systems/spawn-enemies.ts
@@ -6,7 +6,7 @@ const SPAWN_INTERVAL = 1;
 let accumulatedTime = 0;
 
 export const spawnEnemies = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 	const { spawnEnemy } = actions(world);
 
 	accumulatedTime += delta;

--- a/benches/apps/revade/src/systems/tick-explosion.ts
+++ b/benches/apps/revade/src/systems/tick-explosion.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Explosion, Time } from '../traits';
 
 export const tickExplosion = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 	world.query(Explosion).updateEach(([explosion], entity) => {
 		explosion.current += delta * 1000;
 		if (explosion.current >= explosion.duration) {

--- a/benches/apps/revade/src/systems/tick-shield-visibility.ts
+++ b/benches/apps/revade/src/systems/tick-shield-visibility.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { ShieldVisibility, Time, IsShieldVisible } from '../traits';
 
 export const tickShieldVisibility = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 	world.query(ShieldVisibility).updateEach(([shield], entity) => {
 		shield.current += delta * 1000;
 

--- a/benches/apps/revade/src/systems/update-auto-rotate.ts
+++ b/benches/apps/revade/src/systems/update-auto-rotate.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { AutoRotate, Time, Transform } from '../traits';
 
 export const updateAutoRotate = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 	world.query(Transform, AutoRotate).updateEach(([{ rotation }, autoRotate]) => {
 		rotation.x = rotation.y += delta * autoRotate.speed;
 	});

--- a/benches/apps/revade/src/systems/update-avoidance.ts
+++ b/benches/apps/revade/src/systems/update-avoidance.ts
@@ -5,7 +5,7 @@ import { Avoidance, Movement, SpatialHashMap, Transform } from '../traits';
 const acceleration = new THREE.Vector3();
 
 export const updateAvoidance = ({ world }: { world: World }) => {
-	const spatialHashMap = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap)!;
 
 	world
 		.query(Avoidance, Transform, Movement)
@@ -22,7 +22,7 @@ export const updateAvoidance = ({ world }: { world: World }) => {
 			neighbors = neighbors.filter((neighbor) => {
 				return (
 					neighbor.has(Avoidance) &&
-					neighbor.get(Transform).position.distanceTo(position) <= avoidance.range
+					neighbor.get(Transform)!.position.distanceTo(position) <= avoidance.range
 				);
 			});
 
@@ -30,7 +30,7 @@ export const updateAvoidance = ({ world }: { world: World }) => {
 				acceleration.setScalar(0);
 
 				for (const neighbor of neighbors) {
-					acceleration.add(neighbor.get(Transform).position).sub(position);
+					acceleration.add(neighbor.get(Transform)!.position).sub(position);
 				}
 
 				acceleration.divideScalar(-neighbors.length).normalize().multiplyScalar(2);

--- a/benches/apps/revade/src/systems/update-bullet-collisions.ts
+++ b/benches/apps/revade/src/systems/update-bullet-collisions.ts
@@ -3,7 +3,7 @@ import { Bullet, Explosion, IsEnemy, SpatialHashMap, Transform } from '../traits
 import { between } from '../utils/between';
 
 export const updateBulletCollisions = ({ world }: { world: World }) => {
-	const spatialHashMap = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap)!;
 
 	world
 		.query(Bullet, Transform)
@@ -18,14 +18,14 @@ export const updateBulletCollisions = ({ world }: { world: World }) => {
 
 			const hitEnemy = nearbyEntities.find(
 				(entity) =>
-					entity.has(IsEnemy) && entity.get(Transform).position.distanceTo(position) < 1
+					entity.has(IsEnemy) && entity.get(Transform)!.position.distanceTo(position) < 1
 			);
 
 			if (hitEnemy !== undefined) {
 				// Spawn explosion in enemy's position.
 				world.spawn(
 					Explosion({ count: Math.floor(between(12, 20)) }),
-					Transform({ position: hitEnemy.get(Transform).position.clone() })
+					Transform({ position: hitEnemy.get(Transform)!.position.clone() })
 				);
 
 				// Destroy bullet and enemy.

--- a/benches/apps/revade/src/systems/update-bullet.ts
+++ b/benches/apps/revade/src/systems/update-bullet.ts
@@ -5,7 +5,7 @@ import { Bullet, Time, Transform } from '../traits';
 const tmpVec3 = new THREE.Vector3();
 
 export const updateBullets = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 
 	world.query(Bullet, Transform).updateEach(([bullet, transform], entity) => {
 		// Update bullet position

--- a/benches/apps/revade/src/systems/update-movement.ts
+++ b/benches/apps/revade/src/systems/update-movement.ts
@@ -5,7 +5,7 @@ import { Movement, Time, Transform } from '../traits';
 const tmpvec3 = new THREE.Vector3();
 
 export const updateMovement = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 	world.query(Transform, Movement).updateEach(([transform, { velocity, maxSpeed, force }]) => {
 		// Apply max speed
 		velocity.clampLength(0, maxSpeed);

--- a/benches/apps/revade/src/systems/update-spatial-hashing.ts
+++ b/benches/apps/revade/src/systems/update-spatial-hashing.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { SpatialHashMap, Transform } from '../traits';
 
 export const updateSpatialHashing = ({ world }: { world: World }) => {
-	const spatialHashMap = world.get(SpatialHashMap);
+	const spatialHashMap = world.get(SpatialHashMap)!;
 
 	world.query(Transform).updateEach(([{ position }], entity) => {
 		spatialHashMap.setEntity(entity, position.x, position.y, position.z);

--- a/benches/apps/revade/src/systems/update-time.ts
+++ b/benches/apps/revade/src/systems/update-time.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Time } from '../traits/time';
 
 export const updateTime = ({ world }: { world: World }) => {
-	const time = world.get(Time);
+	const time = world.get(Time)!;
 
 	if (time.then === 0) time.then = performance.now();
 

--- a/benches/sims/add-remove/src/systems/moveBodies.ts
+++ b/benches/sims/add-remove/src/systems/moveBodies.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Position, Time, Velocity } from '../trait';
 
 export const moveBodies = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 
 	world.query(Position, Velocity).updateEach(([position, velocity]) => {
 		position.x += velocity.x * delta;

--- a/benches/sims/add-remove/src/systems/updateGravity.ts
+++ b/benches/sims/add-remove/src/systems/updateGravity.ts
@@ -3,7 +3,7 @@ import { World } from 'koota';
 import { Velocity, Time } from '../trait';
 
 export const updateGravity = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 
 	world.query(Velocity).updateEach(([velocity]) => {
 		// Apply gravity directly to the velocity

--- a/benches/sims/add-remove/src/systems/updateTime.ts
+++ b/benches/sims/add-remove/src/systems/updateTime.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Time } from '../trait/Time';
 
 export const updateTime = ({ world }: { world: World }) => {
-	const time = world.get(Time);
+	const time = world.get(Time)!;
 
 	if (time.then === 0) time.then = performance.now();
 

--- a/benches/sims/n-body/src/systems/handleRepulse.ts
+++ b/benches/sims/n-body/src/systems/handleRepulse.ts
@@ -6,7 +6,7 @@ export const handleRepulse = ({ world }: { world: World }) => {
 	if (repulsors.length === 0) return;
 
 	const bodies = world.query(Position, Velocity, Mass);
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 
 	repulsors.updateEach(([repulse, position, circle], entity) => {
 		// Count down the delay

--- a/benches/sims/n-body/src/systems/moveBodies.ts
+++ b/benches/sims/n-body/src/systems/moveBodies.ts
@@ -3,7 +3,7 @@ import { CONSTANTS } from '../constants';
 import { World } from 'koota';
 
 export const moveBodies = ({ world }: { world: World }) => {
-	const { delta } = world.get(Time);
+	const { delta } = world.get(Time)!;
 
 	world.query(Position, Velocity).updateEach(([position, velocity]) => {
 		position.x += CONSTANTS.SPEED * velocity.x * delta;

--- a/benches/sims/n-body/src/systems/updateTime.ts
+++ b/benches/sims/n-body/src/systems/updateTime.ts
@@ -2,7 +2,7 @@ import { World } from 'koota';
 import { Time } from '../traits/Time';
 
 export const updateTime = ({ world }: { world: World }) => {
-	const time = world.get(Time);
+	const time = world.get(Time)!;
 
 	if (time.then === 0) time.then = performance.now();
 

--- a/packages/core/src/entity/entity-methods-patch.ts
+++ b/packages/core/src/entity/entity-methods-patch.ts
@@ -53,14 +53,22 @@ Number.prototype.changed = function (this: Entity, trait: Trait) {
 Number.prototype.get = function (this: Entity, trait: Trait) {
 	const worldId = this >>> WORLD_ID_SHIFT;
 	const world = universe.worlds[worldId];
-	if (!hasTrait(world, this, trait)) {
-		return undefined;
-	}
-	
-	const ctx = trait[$internal];
+	const worldCtx = world[$internal];
+	// TODO: Remove the need for a map to get the entity mask for the trait.
+	const data = worldCtx.traitData.get(trait);
+
+	// If the trait does not exist on the world return undefined.
+	if (!data) return undefined;
+
+	// If the entity does not have the trait return undefined.
+	const mask = worldCtx.entityMasks[data.generationId][this];
+	if ((mask & data.bitflag) !== data.bitflag) return undefined;
+
+	// Return a snapshot of the trait state.
+	const traitCtx = trait[$internal];
 	const index = this & ENTITY_ID_MASK;
-	const store = ctx.stores[worldId];
-	return ctx.get(index, store);
+	const store = traitCtx.stores[worldId];
+	return traitCtx.get(index, store);
 };
 
 // @ts-expect-error

--- a/packages/core/src/entity/entity-methods-patch.ts
+++ b/packages/core/src/entity/entity-methods-patch.ts
@@ -51,9 +51,14 @@ Number.prototype.changed = function (this: Entity, trait: Trait) {
 
 // @ts-expect-error
 Number.prototype.get = function (this: Entity, trait: Trait) {
+	const worldId = this >>> WORLD_ID_SHIFT;
+	const world = universe.worlds[worldId];
+	if (!hasTrait(world, this, trait)) {
+		return undefined;
+	}
+	
 	const ctx = trait[$internal];
 	const index = this & ENTITY_ID_MASK;
-	const worldId = this >>> WORLD_ID_SHIFT;
 	const store = ctx.stores[worldId];
 	return ctx.get(index, store);
 };

--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -14,7 +14,7 @@ export type Entity = number & {
 			| ((prev: TraitInstance<ExtractSchema<T>>) => TraitValue<ExtractSchema<T>>),
 		flagChanged?: boolean
 	) => void;
-	get: <T extends Trait>(trait: T) => TraitInstance<ExtractSchema<T>>;
+	get: <T extends Trait>(trait: T) => TraitInstance<ExtractSchema<T>> | undefined;
 	targetFor: <T extends Trait>(relation: Relation<T>) => Entity | undefined;
 	targetsFor: <T extends Trait>(relation: Relation<T>) => Entity[];
 	id: () => number;

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -96,7 +96,7 @@ export class World {
 		this[$internal].worldEntity.remove(...traits);
 	}
 
-	get<T extends Trait>(trait: T): TraitInstance<ExtractSchema<T>> {
+	get<T extends Trait>(trait: T): TraitInstance<ExtractSchema<T>> | undefined {
 		return this[$internal].worldEntity.get(trait);
 	}
 

--- a/packages/core/tests/entity.test.ts
+++ b/packages/core/tests/entity.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 import { createWorld } from '../src';
 import { trait, getStores } from '../src/trait/trait';
 import { Entity } from '../src/entity/types';
@@ -6,6 +6,7 @@ import { unpackEntity } from '../src/entity/utils/pack-entity';
 
 const Foo = trait();
 const Bar = trait({ value: 0 });
+const Baz = trait(() => ({ value: 0 }));
 
 describe('Entity', () => {
 	const world = createWorld();
@@ -89,6 +90,18 @@ describe('Entity', () => {
 		expect(entity.has(Bar)).toBe(true);
 	});
 
+	it('should return undefined for missing traits', () => {
+		const entity = world.spawn();
+
+		expect(entity.has(Bar)).toBe(false);
+		expect(entity.get(Bar)).toEqual(undefined);
+		expectTypeOf(entity.get(Bar)).toEqualTypeOf<{ value: number } | undefined>();
+
+		expect(entity.has(Baz)).toBe(false);
+		expect(entity.get(Baz)).toBeUndefined();
+		expectTypeOf(entity.get(Baz)).toEqualTypeOf<{ value: number } | undefined>();
+	});
+
 	it('can add traits', () => {
 		const entity = world.spawn();
 
@@ -109,24 +122,24 @@ describe('Entity', () => {
 
 	it('can get trait state', () => {
 		const entity = world.spawn(Bar({ value: 1 }));
-		const bar = entity.get(Bar);
+		const bar = entity.get(Bar)!;
 		expect(bar.value).toBe(1);
 
 		// Changing trait state should not affect the entity.
 		bar.value = 2;
-		expect(entity.get(Bar).value).toBe(1);
+		expect(entity.get(Bar)!.value).toBe(1);
 	});
 
 	it('can set trait state', () => {
 		const entity = world.spawn(Bar);
 		entity.set(Bar, { value: 1 });
-		expect(entity.get(Bar).value).toBe(1);
+		expect(entity.get(Bar)!.value).toBe(1);
 	});
 
 	it('can set trait state with a callback', () => {
 		const entity = world.spawn(Bar);
 		entity.set(Bar, (prev) => ({ value: prev.value + 1 }));
-		expect(entity.get(Bar).value).toBe(1);
+		expect(entity.get(Bar)!.value).toBe(1);
 	});
 
 	it('should trigger change events when trait state is set', () => {

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -605,10 +605,10 @@ describe('Query', () => {
 		});
 
 		expect(query.length).toBe(10);
-		expect(query[0].get(Position).x).toBe(0);
+		expect(query[0].get(Position)!.x).toBe(0);
 
 		for (let i = 1; i < 10; i++) {
-			expect(query[i].get(Position).x).toBe(10);
+			expect(query[i].get(Position)!.x).toBe(10);
 		}
 	});
 
@@ -690,8 +690,8 @@ describe('Query', () => {
 			mass.value = 10;
 		});
 
-		expect(entity.get(Position).x).toBe(1);
-		expect(entity.get(Mass).value).toBe(10);
+		expect(entity.get(Position)!.x).toBe(1);
+		expect(entity.get(Mass)!.value).toBe(10);
 	});
 
 	it('updateEach works with atomic traits and change detection', () => {
@@ -729,6 +729,6 @@ describe('Query', () => {
 		});
 
 		const position = entity.get(Position);
-		expect(position.x).toBe(10);
+		expect(position!.x).toBe(10);
 	});
 });

--- a/packages/core/tests/relation.test.ts
+++ b/packages/core/tests/relation.test.ts
@@ -100,8 +100,8 @@ describe('Relation', () => {
 		inventory.set(Contains(silver), { amount: 12 });
 
 		expect(Contains(gold)).not.toBe(Contains(silver));
-		expect(inventory.get(Contains(gold)).amount).toBe(5);
-		expect(inventory.get(Contains(silver)).amount).toBe(12);
+		expect(inventory.get(Contains(gold))!.amount).toBe(5);
+		expect(inventory.get(Contains(silver))!.amount).toBe(12);
 	});
 
 	it('should query all relations with a wildcard', () => {

--- a/packages/core/tests/trait.test.ts
+++ b/packages/core/tests/trait.test.ts
@@ -189,11 +189,11 @@ describe('Trait', () => {
 		const entityA = world.spawn(Test);
 
 		expect(mock).toHaveBeenCalledTimes(1);
-		expect(entityA.get(Test).value).toBeInstanceOf(TestClass);
+		expect(entityA.get(Test)!.value).toBeInstanceOf(TestClass);
 
 		const entityB = world.spawn(Test);
 		expect(mock).toHaveBeenCalledTimes(2);
-		expect(entityB.get(Test).value).toBeInstanceOf(TestClass);
+		expect(entityB.get(Test)!.value).toBeInstanceOf(TestClass);
 	});
 
 	it('can create atomic traits', () => {
@@ -203,17 +203,17 @@ describe('Trait', () => {
 
 		// The object is returned by reference.
 		expect(object).toBe(entity.get(AtomicObject));
-		expect(entity.get(AtomicObject).a).toBe(1);
+		expect(entity.get(AtomicObject)!.a).toBe(1);
 
 		entity.set(AtomicObject, { a: 2, b: 3 });
 
 		// A new object is set making the reference different.
 		expect(object).not.toBe(entity.get(AtomicObject));
-		expect(entity.get(AtomicObject).a).toBe(2);
+		expect(entity.get(AtomicObject)!.a).toBe(2);
 
 		// Can pass in a custom object into the trait.
 		entity = world.spawn(AtomicObject({ a: 3, b: 4 }));
-		expect(entity.get(AtomicObject).a).toBe(3);
+		expect(entity.get(AtomicObject)!.a).toBe(3);
 		// Works with arrays too.
 		const AtomicArray = trait(() => [1, 2, 3]);
 		entity = world.spawn(AtomicArray);

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -60,7 +60,7 @@ describe('World', () => {
 		const query = world.query(Time);
 		expect(query.length).toBe(0);
 
-		const time = world.get(Time);
+		const time = world.get(Time)!;
 		time.then = 1;
 		time.delta = 1;
 		world.set(Time, time);


### PR DESCRIPTION
### The problem
Hi again! 👋
Before this change, calling `.get` on an entity with a missing trait would cause a different outcome based on the internal state:

- `A` has already been added to any other entity
  - `A` is a struct-of-arrays trait
    - `{}` is returned
  - `A` is an array-of-structs trait
    - `undefined` is returned
- `A` has not yet been used
  - `A` is a struct-of-arrays trait
    - `{}` is returned
  - `A` is an array-of-structs trait
    - ‼️ **An error is raised, as the internal code is trying to index into an undefined** `store`

### Changes
- Always returning `undefined` if a trait was not added to a specific entity. This solution might introduce a loss in efficiency when using `entity.get(...)`, but makes this behavior less dependent on the internal state.

> If the efficiency is really something we would need to keep, then just the error raise could be fixed by replacing `store[index]` with `store?.[index]` in `create-accessors.ts`

- An explicit `| undefined` added to the `.get` method signature, as discussed on Discord.
