### PR TITLE
🏷️ core: wildcard string typed as `'*'`

### DIFF
--- a/packages/core/src/relation/types.ts
+++ b/packages/core/src/relation/types.ts
@@ -2,7 +2,7 @@ import { $internal } from '../common';
 import { Entity } from '../entity/types';
 import { Trait } from '../trait/types';
 
-export type RelationTarget = Entity | string | WildcardRelation;
+export type RelationTarget = Entity | '*' | WildcardRelation;
 
 export type Relation<T extends Trait> = {
 	[$internal]: {


### PR DESCRIPTION
The biggest PR of them all 🌋🦕

### Why?
- Not allowing arbitrary strings into relations
- Better auto-complete