### PR TITLE
✨ core: auto change detection for updateEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,20 @@ entity.set(Position, { x: 10, y: 20 });
 entity.remove(Position);
 ```
 
+### Change detection with `udpateEach`
+
+By default, `updateEach` will automatically turn on change detection for traits that are being tracked via `onChange` or the `Changed` modifier. If you want to silence change detection for a loop or force it to always run, you can do so with an options config.
+
+```js
+// Setting changeDetection to 'never' will silence it, triggering no change events
+world.query(Position, Velocity).updateEach(([position, velocity]) => {
+}, { changeDetection: 'never' });
+
+// Setting changeDetection to 'always' will ignore selective tracking and always emit change events for all traits that are mutated
+world.query(Position, Velocity).updateEach(([position, velocity]) => {
+}, { changeDetection: 'never' });
+```
+
 ### World traits
 
 For global data like time, these can be traits added to the world. **World traits do not appear in queries.**

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -48,7 +48,11 @@ export function createQueryResult<T extends QueryParameter[]>(
 
 				// Get the traits that are being tracked for changes.
 				for (const trait of traits) {
+					// Check if the trait's changes are being tracked via onChange.
+					// Then check if the trait's changes are being tracked via Changed modifiers in the query.
 					if (world[$internal].trackedTraits.has(trait)) {
+						trackedTraits.push(trait);
+					} else if (query.hasChangedModifiers && query.changedTraits.has(trait)) {
 						trackedTraits.push(trait);
 					} else {
 						untrackedTraits.push(trait);

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -35,13 +35,26 @@ export function createQueryResult<T extends QueryParameter[]>(
 	const results = Object.assign(entities, {
 		updateEach(
 			callback: (state: InstancesFromParameters<T>, entity: Entity, index: number) => void,
-			options?: QueryResultOptions
+			options: QueryResultOptions = { changeDetection: 'auto' }
 		) {
-			const changeDetection = options?.changeDetection ?? false;
 			const state = new Array(traits.length);
 
-			// Inline both passive and active updateEach for performance.
-			if (!changeDetection) {
+			// Inline all three permutations of updateEach for performance.
+			if (options.changeDetection === 'auto') {
+				const changedPairs: [Entity, Trait][] = [];
+				const atomicSnapshots: any[] = [];
+				const trackedTraits: Trait[] = [];
+				const untrackedTraits: Trait[] = [];
+
+				// Get the traits that are being tracked for changes.
+				for (const trait of traits) {
+					if (world[$internal].trackedTraits.has(trait)) {
+						trackedTraits.push(trait);
+					} else {
+						untrackedTraits.push(trait);
+					}
+				}
+
 				for (let i = 0; i < entities.length; i++) {
 					const entity = entities[i];
 					const eid = getEntityId(entity);
@@ -50,7 +63,9 @@ export function createQueryResult<T extends QueryParameter[]>(
 					for (let j = 0; j < traits.length; j++) {
 						const trait = traits[j];
 						const ctx = trait[$internal];
-						state[j] = ctx.get(eid, stores[j]);
+						const value = ctx.get(eid, stores[j]);
+						state[j] = value;
+						atomicSnapshots[j] = ctx.type === 'aos' ? { ...value } : null;
 					}
 
 					callback(state as any, entity, i);
@@ -58,14 +73,40 @@ export function createQueryResult<T extends QueryParameter[]>(
 					// Skip if the entity has been destroyed.
 					if (!world.has(entity)) continue;
 
-					// Commit all changes back to the stores.
-					for (let j = 0; j < traits.length; j++) {
-						const trait = traits[j];
+					// Commit all changes back to the stores for tracked traits.
+					for (let j = 0; j < trackedTraits.length; j++) {
+						const trait = trackedTraits[j];
+						const ctx = trait[$internal];
+						const newValue = state[j];
+
+						let changed = false;
+						if (ctx.type === 'aos') {
+							changed = ctx.fastSetWithChangeDetection(eid, stores[j], newValue);
+							if (!changed) {
+								changed = !shallowEqual(newValue, atomicSnapshots[j]);
+							}
+						} else {
+							changed = ctx.fastSetWithChangeDetection(eid, stores[j], newValue);
+						}
+
+						// Collect changed traits.
+						if (changed) changedPairs.push([entity, trait] as const);
+					}
+
+					// Commit all changes back to the stores for untracked traits.
+					for (let j = 0; j < untrackedTraits.length; j++) {
+						const trait = untrackedTraits[j];
 						const ctx = trait[$internal];
 						ctx.fastSet(eid, stores[j], state[j]);
 					}
 				}
-			} else {
+
+				// Trigger change events for each entity that was modified.
+				for (let i = 0; i < changedPairs.length; i++) {
+					const [entity, trait] = changedPairs[i];
+					entity.changed(trait);
+				}
+			} else if (options.changeDetection === 'always') {
 				const changedPairs: [Entity, Trait][] = [];
 				const atomicSnapshots: any[] = [];
 
@@ -112,6 +153,30 @@ export function createQueryResult<T extends QueryParameter[]>(
 				for (let i = 0; i < changedPairs.length; i++) {
 					const [entity, trait] = changedPairs[i];
 					entity.changed(trait);
+				}
+			} else if (options.changeDetection === 'never') {
+				for (let i = 0; i < entities.length; i++) {
+					const entity = entities[i];
+					const eid = getEntityId(entity);
+
+					// Create a snapshot for each trait in the order they appear in the query params.
+					for (let j = 0; j < traits.length; j++) {
+						const trait = traits[j];
+						const ctx = trait[$internal];
+						state[j] = ctx.get(eid, stores[j]);
+					}
+
+					callback(state as any, entity, i);
+
+					// Skip if the entity has been destroyed.
+					if (!world.has(entity)) continue;
+
+					// Commit all changes back to the stores.
+					for (let j = 0; j < traits.length; j++) {
+						const trait = traits[j];
+						const ctx = trait[$internal];
+						ctx.fastSet(eid, stores[j], state[j]);
+					}
 				}
 			}
 

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -41,6 +41,7 @@ export class Query {
 	entities = new SparseSet();
 	isTracking = false;
 	hasChangedModifiers = false;
+	changedTraits = new Set<Trait>();
 	toRemove = new SparseSet();
 	addSubscriptions = new Set<QuerySubscriber>();
 	removeSubscriptions = new Set<QuerySubscriber>();
@@ -117,6 +118,7 @@ export class Query {
 
 				if (parameter.type.includes('changed')) {
 					for (const trait of traits) {
+						this.changedTraits.add(trait);
 						const data = ctx.traitData.get(trait)!;
 						this.traitData.changed.push(data);
 						this.traits.push(trait);

--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -7,7 +7,7 @@ export type QueryParameter = Trait | ReturnType<QueryModifier>;
 export type QuerySubscriber = (entity: Entity) => void;
 
 export type QueryResultOptions = {
-	changeDetection?: boolean;
+	changeDetection?: 'always' | 'auto' | 'never';
 };
 
 export type QueryResult<T extends QueryParameter[] = QueryParameter[]> = readonly Entity[] & {

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -32,6 +32,7 @@ export class World {
 		trackingSnapshots: new Map<number, number[][]>(),
 		changedMasks: new Map<number, number[][]>(),
 		worldEntity: null! as Entity,
+		trackedTraits: new Set<Trait>(),
 	};
 
 	get id() {
@@ -139,6 +140,7 @@ export class World {
 		ctx.trackingSnapshots.clear();
 		ctx.dirtyMasks.clear();
 		ctx.changedMasks.clear();
+		ctx.trackedTraits.clear();
 
 		// Create new world entity.
 		ctx.worldEntity = createEntity(this, IsExcluded);
@@ -213,7 +215,13 @@ export class World {
 		const data = ctx.traitData.get(trait)!;
 		data.changedSubscriptions.add(callback);
 
-		return () => data.changedSubscriptions.delete(callback);
+		// Used by auto change detection to know which traits to track.
+		ctx.trackedTraits.add(trait);
+
+		return () => {
+			data.changedSubscriptions.delete(callback);
+			ctx.trackedTraits.delete(trait);
+		};
 	}
 }
 

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -622,24 +622,18 @@ describe('Query', () => {
 
 		const query = world.query(Position);
 
-		query.updateEach(
-			([position], entity, index) => {
-				if (index === 0) return;
-				position.x = 10;
-			},
-			{ changeDetection: true }
-		);
+		query.updateEach(([position], entity, index) => {
+			if (index === 0) return;
+			position.x = 10;
+		});
 
 		expect(cb).toHaveBeenCalledTimes(9);
 
 		// If values do not change, no events should be triggered.
-		query.updateEach(
-			([position], entity, index) => {
-				if (index === 0) return;
-				position.x = 10;
-			},
-			{ changeDetection: true }
-		);
+		query.updateEach(([position], entity, index) => {
+			if (index === 0) return;
+			position.x = 10;
+		});
 
 		expect(cb).toHaveBeenCalledTimes(9);
 	});
@@ -702,21 +696,36 @@ describe('Query', () => {
 
 		expect(cb).toHaveBeenCalledTimes(0);
 
-		world.query(Position).updateEach(
-			([position]) => {
-				position.x = 0;
-			},
-			{ changeDetection: true }
-		);
+		world.query(Position).updateEach(([position]) => {
+			position.x = 0;
+		});
 
 		expect(cb).toHaveBeenCalledTimes(0);
 
-		world.query(Position).updateEach(
-			([position]) => {
-				position.x = 1;
-			},
-			{ changeDetection: true }
-		);
+		world.query(Position).updateEach(([position]) => {
+			position.x = 1;
+		});
+
+		expect(cb).toHaveBeenCalledTimes(1);
+	});
+
+	it('updaeEach automatically tracks changes for traits observed with onChange', () => {
+		const cb = vi.fn();
+		world.onChange(Position, cb);
+
+		// This has changes tracked automatically.
+		world.spawn(Position);
+		world.query(Position).updateEach(([position]) => {
+			position.x = 1;
+		});
+
+		expect(cb).toHaveBeenCalledTimes(1);
+
+		// This does not have changes tracked automatically.
+		world.spawn(Name);
+		world.query(Name).updateEach(([name]) => {
+			name.name = 'name';
+		});
 
 		expect(cb).toHaveBeenCalledTimes(1);
 	});

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -709,7 +709,7 @@ describe('Query', () => {
 		expect(cb).toHaveBeenCalledTimes(1);
 	});
 
-	it('updaeEach automatically tracks changes for traits observed with onChange', () => {
+	it('updateEach automatically tracks changes for traits observed with onChange', () => {
 		const cb = vi.fn();
 		world.onChange(Position, cb);
 


### PR DESCRIPTION
### Change detection with `udpateEach`

By default, `updateEach` will automatically turn on change detection for traits that are being tracked via `onChange` or the `Changed` modifier. If you want to silence change detection for a loop or force it to always run, you can do so with an options config.

```js
// Setting changeDetection to 'never' will silence it, triggering no change events
world.query(Position, Velocity).updateEach(([position, velocity]) => {
}, { changeDetection: 'never' });

// Setting changeDetection to 'always' will ignore selective tracking and always emit change events for all traits that are mutated
world.query(Position, Velocity).updateEach(([position, velocity]) => {
}, { changeDetection: 'never' });
```