### PR TITLE
🐛 core: entity get works with multi-generation entities again

### DIFF
--- a/packages/core/src/entity/entity-methods-patch.ts
+++ b/packages/core/src/entity/entity-methods-patch.ts
@@ -60,13 +60,15 @@ Number.prototype.get = function (this: Entity, trait: Trait) {
 	// If the trait does not exist on the world return undefined.
 	if (!data) return undefined;
 
+	// Get the entity index/id.
+	const index = this & ENTITY_ID_MASK;
+
 	// If the entity does not have the trait return undefined.
-	const mask = worldCtx.entityMasks[data.generationId][this];
+	const mask = worldCtx.entityMasks[data.generationId][index];
 	if ((mask & data.bitflag) !== data.bitflag) return undefined;
 
 	// Return a snapshot of the trait state.
 	const traitCtx = trait[$internal];
-	const index = this & ENTITY_ID_MASK;
 	const store = traitCtx.stores[worldId];
 	return traitCtx.get(index, store);
 };


### PR DESCRIPTION
Signed-off-by: Kris Baumgartner <kjbaumgartner@gmail.com>