### PR TITLE
🐛 core: entity get works with multi-generation entities again

### DIFF
--- a/packages/core/src/entity/entity-methods-patch.ts
+++ b/packages/core/src/entity/entity-methods-patch.ts
@@ -60,13 +60,15 @@ Number.prototype.get = function (this: Entity, trait: Trait) {
 	// If the trait does not exist on the world return undefined.
 	if (!data) return undefined;
 
+	// Get entity index/id.
+	const index = this & ENTITY_ID_MASK;
+
 	// If the entity does not have the trait return undefined.
-	const mask = worldCtx.entityMasks[data.generationId][this];
+	const mask = worldCtx.entityMasks[data.generationId][index];
 	if ((mask & data.bitflag) !== data.bitflag) return undefined;
 
 	// Return a snapshot of the trait state.
 	const traitCtx = trait[$internal];
-	const index = this & ENTITY_ID_MASK;
 	const store = traitCtx.stores[worldId];
 	return traitCtx.get(index, store);
 };

--- a/packages/core/tests/entity.test.ts
+++ b/packages/core/tests/entity.test.ts
@@ -121,12 +121,18 @@ describe('Entity', () => {
 	});
 
 	it('can get trait state', () => {
-		const entity = world.spawn(Bar({ value: 1 }));
+		let entity = world.spawn(Bar({ value: 1 }));
 		const bar = entity.get(Bar)!;
 		expect(bar.value).toBe(1);
 
 		// Changing trait state should not affect the entity.
 		bar.value = 2;
+		expect(entity.get(Bar)!.value).toBe(1);
+
+		// Check this works with multi-generational entities.
+		entity.destroy();
+
+		entity = world.spawn(Bar({ value: 1 }));
 		expect(entity.get(Bar)!.value).toBe(1);
 	});
 


### PR DESCRIPTION
Signed-off-by: Kris Baumgartner <kjbaumgartner@gmail.com>