### PR TITLE
💥 core: queries with empty params return all queryable entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,15 @@ const movedEntities = world.query(Changed(Position));
 // After running the query, the Changed modifier is reset
 ```
 
+### Query all entities
+
+To get al queryable entities you simply query with not paramerters. Note, that not all entities are queryable. Any entity that has `IsExcluded` will not be able to be queried. This is used in Koota to exclude world entities, for example, but maybe used for other system level entities in the future. To get all entities regardless, use `world.entities`.
+
+```js
+// Returns all queryable entities
+const allQueryableEntities = world.query()
+```
+
 ### Add, remove and change events
 
 Koota allows you to subscribe to add, remove, and change events for specific traits.
@@ -427,7 +436,7 @@ const unsub = world.onAdd([Position], (entity) => {})
 const unsub = world.onRemove([Position], (entity) => {})
 const unsub = world.onChange([Position], (entity) => {})
 
-// An array of all entities alive in the world
+// An array of all entities alive in the world, including non-queryable entities
 // This is a copy so editing it won't do anything!
 // Entity[]
 world.entities

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -142,6 +142,9 @@ export class Query {
 			}
 		}
 
+		// Add IsExcluded to the forbidden list.
+		this.traitData.forbidden.push(ctx.traitData.get(IsExcluded)!);
+
 		this.traitData.all = [
 			...this.traitData.required,
 			...this.traitData.forbidden,
@@ -274,8 +277,6 @@ export class Query {
 				const entities = ctx.entityIndex.dense;
 				for (let i = 0; i < entities.length; i++) {
 					const entity = entities[i];
-					// Skip if the entity is excluded.
-					if (entity.has(IsExcluded)) continue;
 					const match = this.check(world, entity);
 					if (match) this.add(entity);
 				}

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -80,10 +80,15 @@ describe('Query', () => {
 		expect(ctx.queriesHashMap.size).toBe(2);
 	});
 
-	it('should return an empty array if there are no query parameters', () => {
+	it('should return all queryable entities when parameters are empty', () => {
 		world.spawn();
+		// IsExcluded marks the entity is non-queryable.
+		world.spawn(IsExcluded);
+		world.spawn(Position);
+		world.spawn(Name, Bar);
 		const entities = world.query();
-		expect(entities.length).toBe(0);
+
+		expect(entities.length).toBe(3);
 	});
 
 	it('should correctly populate Not queries when traits are added and removed', () => {


### PR DESCRIPTION
This PR makes a rather simple change but clarifies internal concepts. 

Perviously querying with empty params returned no entities, ie`world.query()`. Now it returns all queryable entities.

What are queryable entities? We have a system level tag called `IsExcluded` that can be used to make any entity non-queryable. This is used interally for world entities but also for possible features like prefabs and inheritance. These entities are not queryable, so you can add trais to the world without worrying about it polluting queries.

To get all entities, even non-queryable ones you can access `world.entities`.

Signed-off-by: Kris Baumgartner <kjbaumgartner@gmail.com>