### PR TITLE
🐛 react: useQuery was unstable with the same params

### DIFF
--- a/packages/react/src/hooks/use-query.ts
+++ b/packages/react/src/hooks/use-query.ts
@@ -3,29 +3,28 @@ import { useEffect, useMemo, useReducer } from 'react';
 import { useWorld } from '../world/use-world';
 
 export function useQuery<T extends QueryParameter[]>(...parameters: T): QueryResult<T> {
-	const memoizedParameters = useMemo(() => parameters, [parameters]);
 	const world = useWorld();
-	const entities = useMemo(() => world.query(...memoizedParameters), [world, memoizedParameters]);
+	const entities = useMemo(() => world.query(...parameters), [world, ...parameters]);
 	const [, forceUpdate] = useReducer((v) => v + 1, 0);
 
 	// Set entities at effect time
 	useEffect(() => {
 		const mutableEntities = entities as unknown as Entity[];
 		mutableEntities.length = 0;
-		mutableEntities.push(...world.query(...memoizedParameters));
+		mutableEntities.push(...world.query(...parameters));
 
 		forceUpdate();
 	}, [world]);
 
 	// Subscribe to changes
 	useEffect(() => {
-		const unsubAdd = world.onAdd(memoizedParameters, (entity) => {
+		const unsubAdd = world.onAdd(parameters, (entity) => {
 			const mutableEntities = entities as unknown as Entity[];
 			mutableEntities.push(entity);
 			forceUpdate();
 		});
 
-		const unsubRemove = world.onRemove(memoizedParameters, (entity) => {
+		const unsubRemove = world.onRemove(parameters, (entity) => {
 			const mutableEntities = entities as unknown as Entity[];
 			const index = mutableEntities.indexOf(entity);
 			mutableEntities[index] = mutableEntities[mutableEntities.length - 1];


### PR DESCRIPTION
In `useQuery`, the generated entity array should be stable *unless* the parameters change, but it would regenerate the array every rerender anyways making the memoization uselss. This fixes the case and creates a test to keep track of this behavior.