### PR TITLE
Make `useQuery` immutable and more stable

### DIFF
--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -13,6 +13,7 @@ import { getEntityId } from '../entity/utils/pack-entity';
 export const IsExcluded = trait();
 
 export class Query {
+	version = 0;
 	world: World;
 	parameters: QueryParameter[];
 	hash: string;
@@ -302,6 +303,8 @@ export class Query {
 		for (const sub of this.addSubscriptions) {
 			sub(entity);
 		}
+
+		this.version++;
 	}
 
 	remove(world: World, entity: Entity) {

--- a/packages/react/src/hooks/use-query.ts
+++ b/packages/react/src/hooks/use-query.ts
@@ -1,42 +1,41 @@
-import { Entity, QueryParameter, QueryResult } from '@koota/core';
-import { useEffect, useMemo, useReducer } from 'react';
+import { $internal, cacheQuery, QueryParameter, QueryResult } from '@koota/core';
+import { useEffect, useMemo, useState } from 'react';
 import { useWorld } from '../world/use-world';
 
 export function useQuery<T extends QueryParameter[]>(...parameters: T): QueryResult<T> {
 	const world = useWorld();
-	const entities = useMemo(() => world.query(...parameters), [world, ...parameters]);
-	const [, forceUpdate] = useReducer((v) => v + 1, 0);
 
-	// Set entities at effect time
-	useEffect(() => {
-		const mutableEntities = entities as unknown as Entity[];
-		mutableEntities.length = 0;
-		mutableEntities.push(...world.query(...parameters));
+	const [hash, initialVersion] = useMemo(() => {
+		const hash = cacheQuery(...parameters);
+		// Using internals to get the query data
+		const query = world[$internal].queriesHashMap.get(hash)!;
+		return [hash, query.version];
+	}, [parameters]);
 
-		forceUpdate();
-	}, [world]);
+	const [entities, setEntities] = useState<QueryResult<T>>(() => world.query(hash));
 
 	// Subscribe to changes
 	useEffect(() => {
-		const unsubAdd = world.onAdd(parameters, (entity) => {
-			const mutableEntities = entities as unknown as Entity[];
-			mutableEntities.push(entity);
-			forceUpdate();
+		const unsubAdd = world.onAdd(parameters, () => {
+			setEntities(world.query(hash));
 		});
 
-		const unsubRemove = world.onRemove(parameters, (entity) => {
-			const mutableEntities = entities as unknown as Entity[];
-			const index = mutableEntities.indexOf(entity);
-			mutableEntities[index] = mutableEntities[mutableEntities.length - 1];
-			mutableEntities.pop();
-			forceUpdate();
+		const unsubRemove = world.onRemove(parameters, () => {
+			setEntities(world.query(hash));
 		});
+
+		// Compare the initial version to the current version to
+		// see it the query has changed
+		const query = world[$internal].queriesHashMap.get(hash)!;
+		if (query.version !== initialVersion) {
+			setEntities(world.query(hash));
+		}
 
 		return () => {
 			unsubAdd();
 			unsubRemove();
 		};
-	}, [world]);
+	}, [world, hash]);
 
 	return entities;
 }

--- a/packages/react/tests/query.test.tsx
+++ b/packages/react/tests/query.test.tsx
@@ -1,8 +1,9 @@
 import { createWorld, Entity, QueryResult, trait, universe, World } from '@koota/core';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
-import { act, StrictMode } from 'react';
+import { act, ReactNode, StrictMode } from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useQuery, WorldProvider } from '../src';
+import exp from 'constants';
 
 declare global {
 	var IS_REACT_ACT_ENVIRONMENT: boolean;
@@ -13,6 +14,7 @@ global.IS_REACT_ACT_ENVIRONMENT = true;
 
 let world: World;
 const Position = trait({ x: 0, y: 0 });
+const Velocity = trait({ x: 0, y: 0 });
 
 describe('useQuery', () => {
 	beforeEach(() => {
@@ -60,55 +62,155 @@ describe('useQuery', () => {
 		expect(entities.length).toBe(1);
 	});
 
-	it('is stable when the query parameters are the same', async () => {
-		const Velocity = trait({ x: 0, y: 0 });
-		const Health = trait({ value: 100 });
+	it('captures entities added during effect timing', async () => {
+		// Spawn an initial entity
+		world.spawn(Position);
 
-		let entities: QueryResult = null!;
-		let prevEntities: QueryResult = null!;
+		let entities: QueryResult<[typeof Position]> = null!;
 
-		function Test({ changeOrder }: { changeOrder: boolean }) {
-			entities = useQuery(
-				...(changeOrder ? [Position, Velocity, Health] : [Position, Health, Velocity])
-			);
+		function Test() {
+			entities = useQuery(Position);
 			return null;
+		}
+
+		// Spawn an entity in the ref callback, which is after the
+		// render function but before effects run
+		function EntityAdder() {
+			return (
+				<mesh
+					ref={() => {
+						world.spawn(Position);
+					}}
+				/>
+			);
 		}
 
 		await act(async () => {
 			await ReactThreeTestRenderer.create(
 				<StrictMode>
 					<WorldProvider world={world}>
-						<Test changeOrder={false} />
+						<Test />
+						<EntityAdder />
 					</WorldProvider>
 				</StrictMode>
 			);
 		});
 
-		expect(entities.length).toBe(0);
-		prevEntities = entities;
+		expect(entities.length).toBe(2);
+	});
 
-		await act(async () => {
-			world.spawn(Position, Velocity, Health);
-		});
+	it('renders once if entities do not change before effect', async () => {
+		// Spawn an initial entity
+		world.spawn(Position);
 
-		expect(entities.length).toBe(1);
-		// Test that the entities array is stable when the query parameters are the same
-		expect(entities).toBe(prevEntities);
-		prevEntities = entities;
+		let entities: QueryResult<[typeof Position]> = null!;
+		let renderCount = 0;
 
-		// But unstable when the order of the parameters is different
+		function Test() {
+			entities = useQuery(Position);
+			renderCount++;
+			return null;
+		}
+
+		// Test without strict mode
 		await act(async () => {
 			await ReactThreeTestRenderer.create(
-				<StrictMode>
-					<WorldProvider world={world}>
-						<Test changeOrder={true} />
-					</WorldProvider>
-				</StrictMode>
+				<WorldProvider world={world}>
+					<Test />
+				</WorldProvider>
 			);
 		});
 
-		expect(entities.length).toBe(1);
-		expect(entities).not.toBe(prevEntities);
-		prevEntities = entities;
+		expect(renderCount).toBe(1);
 	});
+
+	it('renders twice if entities change before effect', async () => {
+		// Spawn Two initial entities
+		const entity = world.spawn(Position);
+		world.spawn(Position);
+
+		let entities: QueryResult<[typeof Position]> = null!;
+		let renderCount = 0;
+
+		function Test() {
+			entities = useQuery(Position);
+			renderCount++;
+			return null;
+		}
+
+		// Add and remove an entity so the total number
+		// is the same but the contents change
+		function EntityAdder() {
+			return (
+				<mesh
+					ref={() => {
+						world.spawn(Position);
+						entity.destroy();
+					}}
+				/>
+			);
+		}
+
+		await act(async () => {
+			await ReactThreeTestRenderer.create(
+				<WorldProvider world={world}>
+					<Test />
+					<EntityAdder />
+				</WorldProvider>
+			);
+		});
+
+		expect(renderCount).toBe(2);
+	});
+
+	// it('updates when query parameters change', async () => {
+	// 	// Create entities with different traits
+	// 	const positionEntity = world.spawn(Position);
+	// 	const bothEntity = world.spawn(Position, Velocity);
+
+	// 	let entities: QueryResult<any> = null!;
+	// 	let queryParams: any[] = [Position];
+	// 	let rerender: () => Promise<void>;
+
+	// 	function Test() {
+	// 		entities = useQuery(...queryParams);
+	// 		return null;
+	// 	}
+
+	// 	// Render with initial parameters
+	// 	await act(async () => {
+	// 		const renderer = await ReactThreeTestRenderer.create(
+	// 			<StrictMode>
+	// 				<WorldProvider world={world}>
+	// 					<Test />
+	// 				</WorldProvider>
+	// 			</StrictMode>
+	// 		);
+
+	// 		rerender = async () => {
+	// 			await renderer.update(
+	// 				<StrictMode>
+	// 					<WorldProvider world={world}>
+	// 						<Test />
+	// 					</WorldProvider>
+	// 				</StrictMode>
+	// 			);
+	// 		};
+	// 	});
+
+	// 	// Should have both entities with Position
+	// 	expect(entities.length).toBe(2);
+	// 	expect(entities).toContain(positionEntity);
+	// 	expect(entities).toContain(bothEntity);
+
+	// 	// Change query parameters
+	// 	await act(async () => {
+	// 		queryParams = [Position, Velocity];
+	// 		await rerender();
+	// 	});
+
+	// 	// Should now only have the entity with both Position and Velocity
+	// 	expect(entities.length).toBe(1);
+	// 	expect(entities[0]).toBe(bothEntity);
+	// });
 });


### PR DESCRIPTION
This PR makes `useQuery` immutable, so it returns a new array on each update and also makes it so `useQuery` only rerenders on effect if there is an actual change in the query result.

This conforms to React expectations and should fix a lot of confusion users have been encountering.