### PR TITLE
Fix relation store get type with get method

### DIFF
--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -14,7 +14,7 @@ export type Entity = number & {
 			| ((prev: TraitInstance<ExtractSchema<T>>) => TraitValue<ExtractSchema<T>>),
 		flagChanged?: boolean
 	) => void;
-	get: <T extends Trait>(trait: T) => TraitInstance<ExtractSchema<T>> | undefined;
+	get: <T extends Trait | Relation<Trait>>(trait: T) => TraitInstance<ExtractSchema<T>> | undefined;
 	targetFor: <T extends Trait>(relation: Relation<T>) => Entity | undefined;
 	targetsFor: <T extends Trait>(relation: Relation<T>) => Entity[];
 	id: () => number;

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -13,6 +13,7 @@ import { getEntityId } from '../entity/utils/pack-entity';
 export const IsExcluded = trait();
 
 export class Query {
+	version = 0;
 	world: World;
 	parameters: QueryParameter[];
 	hash: string;
@@ -302,6 +303,8 @@ export class Query {
 		for (const sub of this.addSubscriptions) {
 			sub(entity);
 		}
+
+		this.version++;
 	}
 
 	remove(world: World, entity: Entity) {

--- a/packages/core/src/relation/relation.ts
+++ b/packages/core/src/relation/relation.ts
@@ -4,18 +4,23 @@ import { $internal } from '../common';
 import { World } from '../world/world';
 import { Relation, RelationTarget, WildcardRelation } from './types';
 
-function defineRelation<S extends Schema = any, T extends Trait = Trait<Schema>>(definition?: {
+function defineRelation<S extends Schema = any>(definition?: {
 	exclusive?: boolean;
 	autoRemoveTarget?: boolean;
 	store?: S;
-}): Relation<T> {
-	const pairsMap = new Map<any, T>();
-	const traitFactory = () => trait(definition?.store ?? {}) as T;
+}): Relation<Trait<S>> {
+	const pairsMap = new Map<any, Trait<S>>();
+	const traitFactory = () => trait(definition?.store ?? {}) as unknown as Trait<S>;
 
 	function relationFn(target: RelationTarget) {
 		if (target === undefined) throw Error('Relation target is undefined');
 		if (target === '*') target = Wildcard as RelationTarget;
-		return getRelationTrait<T>(relationFn as Relation<T>, traitFactory, pairsMap, target);
+		return getRelationTrait<Trait<S>>(
+			relationFn as Relation<Trait<S>>,
+			traitFactory,
+			pairsMap,
+			target
+		);
 	}
 
 	return Object.assign(relationFn, {
@@ -25,7 +30,7 @@ function defineRelation<S extends Schema = any, T extends Trait = Trait<Schema>>
 			exclusive: definition?.exclusive ?? false,
 			autoRemoveTarget: definition?.autoRemoveTarget ?? false,
 		},
-	}) as Relation<T>;
+	}) as Relation<Trait<S>>;
 }
 export const relation = defineRelation;
 

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -93,7 +93,11 @@ export type Norm<T extends Schema> = T extends AoSFactory
 			[K in keyof T]: T[K] extends boolean ? boolean : T[K];
 	  };
 
-export type ExtractSchema<T extends Trait> = T extends Trait<infer S, any> ? S : never;
+export type ExtractSchema<T extends Trait | Relation<Trait>> = T extends Relation<infer R>
+	? ExtractSchema<R>
+	: T extends Trait<infer S>
+	? S
+	: never;
 export type ExtractStore<T extends Trait> = T extends Trait<any, infer S> ? S : never;
 export type ExtractIsTag<T extends Trait> = T extends Trait<any, any, infer Tag> ? Tag : false;
 


### PR DESCRIPTION
This fixes the relation store get type with entity get method.

```js
const Contains = relation({ store: { amount: 0 } });

const gold = world.spawn();
const entity = world.spawn(Contains(gold));

const amount = entity.get(Contains(gold))!; // Should be type { amount: number }
```