### PR TITLE
🏷️ core: add sort method to QueryResult type

### DIFF
--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -19,6 +19,7 @@ export type QueryResult<T extends QueryParameter[] = QueryParameter[]> = readonl
 		callback: (stores: StoresFromParameters<T>, entities: readonly Entity[]) => void
 	) => QueryResult<T>;
 	select<U extends QueryParameter[]>(...params: U): QueryResult<U>;
+	sort(callback: (entity: Entity) => number): QueryResult<T>;
 };
 
 type UnwrapModifierData<T> = T extends ModifierData<infer C> ? C : never;


### PR DESCRIPTION
Even though a QueryResult is technically readonly, it is useful to sort the results without adding or removing members.