### PR TITLE
✨ core: world is now GC safe

### DIFF
--- a/benches/apps/n-body-react/src/App.tsx
+++ b/benches/apps/n-body-react/src/App.tsx
@@ -1,15 +1,21 @@
 import { Canvas, useFrame } from '@react-three/fiber';
 import { CONSTANTS, init, schedule } from '@sim/n-body';
 import { useSchedule } from 'directed/react';
-import { Entity } from 'koota';
+import { createWorld, Entity, universe } from 'koota';
 import { useActions, useWorld } from 'koota/react';
-import { StrictMode, useLayoutEffect, useRef } from 'react';
+import { StrictMode, useLayoutEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { cleanupBodies } from './systems/cleanupRepulsors';
 import { syncThreeObjects } from './systems/syncThreeObjects';
 import { InstancedMesh } from './traits/InstancedMesh';
 import { actions } from './actions';
 import { useStats } from './use-stats';
+
+function WorldGCGTest() {
+	const world = useMemo(() => createWorld(), []);
+
+	return null;
+}
 
 export function App() {
 	const frustumSize = 7000;
@@ -31,6 +37,8 @@ export function App() {
 	useLayoutEffect(() => {
 		spawnCentralMasses(1);
 		spawnBodies(CONSTANTS.NBODIES - 1);
+
+		console.log(universe.worldIndex, universe.worlds);
 
 		return () => {
 			destroyAllBodies();

--- a/packages/core/src/entity/entity-methods-patch.ts
+++ b/packages/core/src/entity/entity-methods-patch.ts
@@ -18,63 +18,63 @@ import { isEntityAlive } from './utils/entity-index';
 // @ts-expect-error
 Number.prototype.add = function (this: Entity, ...traits: ConfigurableTrait[]) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return addTrait(world, this, ...traits);
 };
 
 // @ts-expect-error
 Number.prototype.remove = function (this: Entity, ...traits: Trait[]) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return removeTrait(world, this, ...traits);
 };
 
 // @ts-expect-error
 Number.prototype.has = function (this: Entity, trait: Trait) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return hasTrait(world, this, trait);
 };
 
 // @ts-expect-error
 Number.prototype.destroy = function (this: Entity) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return destroyEntity(world, this);
 };
 
 // @ts-expect-error
 Number.prototype.changed = function (this: Entity, trait: Trait) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return setChanged(world, this, trait);
 };
 
 // @ts-expect-error
 Number.prototype.get = function (this: Entity, trait: Trait) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return getTrait(world, this, trait);
 };
 
 // @ts-expect-error
 Number.prototype.set = function (this: Entity, trait: Trait, value: any, triggerChanged = true) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	setTrait(world, this, trait, value, triggerChanged);
 };
 
 //@ts-expect-error
 Number.prototype.targetsFor = function (this: Entity, relation: Relation<any>) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return getRelationTargets(world, relation, this);
 };
 
 //@ts-expect-error
 Number.prototype.targetFor = function (this: Entity, relation: Relation<any>) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return getRelationTargets(world, relation, this)[0];
 };
 
@@ -87,6 +87,6 @@ Number.prototype.id = function (this: Entity) {
 //@ts-expect-error
 Number.prototype.isAlive = function (this: Entity) {
 	const worldId = this >>> WORLD_ID_SHIFT;
-	const world = universe.worlds[worldId];
+	const world = universe.worlds[worldId]!.deref()!;
 	return isEntityAlive(world[$internal].entityIndex, this);
 };

--- a/packages/core/src/query/modifiers/added.ts
+++ b/packages/core/src/query/modifiers/added.ts
@@ -8,7 +8,7 @@ export function createAdded() {
 
 	for (const world of universe.worlds) {
 		if (!world) continue;
-		setTrackingMasks(world, id);
+		setTrackingMasks(world.deref()!, id);
 	}
 
 	return <T extends Trait[] = Trait[]>(...traits: T) =>

--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -13,7 +13,7 @@ export function createChanged() {
 
 	for (const world of universe.worlds) {
 		if (!world) continue;
-		setTrackingMasks(world, id);
+		setTrackingMasks(world.deref()!, id);
 	}
 
 	return <T extends Trait[] = Trait[]>(...traits: T) =>

--- a/packages/core/src/query/modifiers/removed.ts
+++ b/packages/core/src/query/modifiers/removed.ts
@@ -8,7 +8,7 @@ export function createRemoved() {
 
 	for (const world of universe.worlds) {
 		if (!world) continue;
-		setTrackingMasks(world, id);
+		setTrackingMasks(world.deref()!, id);
 	}
 
 	return <T extends Trait[] = Trait[]>(...traits: T) =>

--- a/packages/core/src/query/utils/cache-query.ts
+++ b/packages/core/src/query/utils/cache-query.ts
@@ -7,8 +7,9 @@ import { createQueryHash } from './create-query-hash';
 export function cacheQuery<T extends QueryParameter[]>(...parameters: T): QueryHash<T> {
 	const hash = createQueryHash(parameters);
 
-	for (const world of universe.worlds) {
-		if (!world) continue;
+	for (const worldRef of universe.worlds) {
+		if (!worldRef) continue;
+		const world = worldRef.deref()!;
 		const ctx = world[$internal];
 		if (!ctx.queriesHashMap.has(hash)) {
 			const query = new Query(world, parameters);

--- a/packages/core/src/universe/universe.ts
+++ b/packages/core/src/universe/universe.ts
@@ -4,11 +4,11 @@ import { createWorldIndex } from '../world/utils/world-index';
 import { World } from '../world/world';
 
 export const universe = {
-	worlds: new Array<World>(WORLD_ID_BITS ** 2),
+	worlds: new Array<WeakRef<World> | null>(WORLD_ID_BITS ** 2),
 	cachedQueries: new Map<string, QueryParameter[]>(),
 	worldIndex: createWorldIndex(),
 	reset: () => {
-		universe.worlds = new Array<World>(WORLD_ID_BITS ** 2);
+		universe.worlds = new Array<WeakRef<World> | null>(WORLD_ID_BITS ** 2).fill(null);
 		universe.cachedQueries = new Map();
 		universe.worldIndex = createWorldIndex();
 	},

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -15,7 +15,8 @@ describe('World', () => {
 
 		expect(world.isInitialized).toBe(true);
 		expect(world.id).toBe(0);
-		expect(universe.worlds).toContain(world);
+		expect(universe.worlds[0]!.deref()!).toBe(world);
+		expect(universe.worldIndex.worldCursor).toBe(1);
 	});
 
 	it('should reset the world', () => {


### PR DESCRIPTION
This PR makes it so `universe` no longer holds a strong reference on worlds allowing them to be GCed. A finalization registry is used to release its ID. This allows for patterns like creating a world in a `useMemo` without side effects if it is discarded immediately.