### PR TITLE
💥 react: remove default world

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ return player ? (
 
 ### `useWorld` 
 
-Returns the default world. If a world is passed in via `WorldProvider` then this is returned instead. The default world can be gotten at any time with `getDefaultWorld`.
+Returns the world held in context via `WorldProvider`.
 
 ```js
 // Get the default world
@@ -663,7 +663,7 @@ useEffect(() => {
 
 ### `WorldProvider` 
 
-The provider for the world context. A world must be created and passed in, which then overrides the default world.
+The provider for the world context. A world must be created and passed in.
 
 ```js
 // Create a world and pass it to the provider

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,4 +5,3 @@ export { useActions } from './hooks/use-actions';
 export { useTrait } from './hooks/use-trait';
 export { useQueryFirst } from './hooks/use-query-first';
 export { useTraitEffect } from './hooks/use-trait-effect';
-export { getDefaultWorld } from './world/default-world';

--- a/packages/react/src/world/default-world.ts
+++ b/packages/react/src/world/default-world.ts
@@ -1,5 +1,0 @@
-import { createWorld } from '@koota/core';
-
-export const defaultWorld = createWorld();
-
-export const getDefaultWorld = () => defaultWorld;

--- a/packages/react/src/world/use-world.ts
+++ b/packages/react/src/world/use-world.ts
@@ -1,8 +1,6 @@
 import { useContext } from 'react';
 import { WorldContext } from './world-context';
-import { defaultWorld } from './default-world';
 
 export function useWorld() {
-	const world = useContext(WorldContext) ?? defaultWorld;
-	return world;
+	return useContext(WorldContext);
 }

--- a/packages/react/tests/world.test.tsx
+++ b/packages/react/tests/world.test.tsx
@@ -1,7 +1,7 @@
 import { universe, World } from '@koota/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createWorld } from '@koota/core';
-import { getDefaultWorld, useWorld, WorldProvider } from '../src';
+import { useWorld, WorldProvider } from '../src';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
 import { act, StrictMode } from 'react';
 
@@ -39,20 +39,5 @@ describe('World', () => {
 		});
 
 		expect(worldTest).toBe(world);
-	});
-
-	it('provides the default world if no world is provided', async () => {
-		let worldTest: World | null = null;
-
-		function Test() {
-			worldTest = useWorld();
-			return null;
-		}
-
-		await act(async () => {
-			await ReactThreeTestRenderer.create(<Test />);
-		});
-
-		expect(worldTest).toBe(getDefaultWorld());
 	});
 });


### PR DESCRIPTION
Removes the default world from the React package, making it a requirement to use `WorldProvider`. I thought it would make it easier to get started with one less step, but it introduced edge cases because it is easy to forget there is an extra world floating around.