### PR TITLE
Add world reset options

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,15 @@ world.entities
 const id = world.id()
 
 // Resets the world as if it were just created
-world.reset()
+// Options can be passed in to modify the reset behavior
+world.reset({
+  // Default false. If true, does not clear cached queries
+  preserveQueries: false 
+  // Default false. If true, does not clear cached traits
+  preserveTraits: false 
+  // Default false. If true, does not clear subscrptions, queries or traits
+  preserveSubscriptions: false 
+})
 
 // Nukes the world and releases its ID
 world.destroy()

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -14,6 +14,12 @@ import { ConfigurableTrait, ExtractSchema, Trait, TraitInstance, TraitValue } fr
 import { universe } from '../universe/universe';
 import { allocateWorldId, releaseWorldId } from './utils/world-index';
 
+type ResetOptions = {
+	preserveQueries?: boolean;
+	preserveTraits?: boolean;
+	preserveSubscriptions?: boolean;
+};
+
 export class World {
 	#id = allocateWorldId(universe.worldIndex);
 
@@ -120,21 +126,28 @@ export class World {
 		universe.worlds[this.#id] = null;
 	}
 
-	reset() {
+	reset(options: ResetOptions = {}) {
 		const ctx = this[$internal];
+		const shouldPreserveTraits = options.preserveTraits || options.preserveSubscriptions;
+		const shouldPreserveQueries = options.preserveQueries || options.preserveSubscriptions;
 
 		ctx.entityIndex = createEntityIndex(this.#id);
 		ctx.entityTraits.clear();
-		ctx.notQueries.clear();
 		ctx.entityMasks = [[]];
 		ctx.bitflag = 1;
 
-		ctx.traitData.clear();
-		this.traits.clear();
+		if (!shouldPreserveTraits) {
+			ctx.traitData.clear();
+			this.traits.clear();
+		}
 
-		ctx.queries.clear();
-		ctx.queriesHashMap.clear();
-		ctx.dirtyQueries.clear();
+		if (!shouldPreserveQueries) {
+			ctx.queries.clear();
+			ctx.queriesHashMap.clear();
+			ctx.dirtyQueries.clear();
+			ctx.notQueries.clear();
+		}
+
 		ctx.relationTargetEntities.clear();
 
 		ctx.trackingSnapshots.clear();

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { universe } from '../src/universe/universe';
-import { trait } from '../src/trait/trait';
 import { createWorld, TraitInstance } from '../src';
+import { trait } from '../src/trait/trait';
+import { universe } from '../src/universe/universe';
 
 describe('World', () => {
 	beforeEach(() => {
@@ -88,5 +88,34 @@ describe('World', () => {
 
 		world.set(TimeOfDay, { hour: 1 });
 		expect(timeOfDay).toEqual({ hour: 1 });
+	});
+
+	it('should preserve subscriptions when reset with preserveSubscriptions', () => {
+		const world = createWorld();
+		const Position = trait({ x: 0, y: 0 });
+
+		let addCounter = 0;
+		let removeCounter = 0;
+
+		world.onAdd([Position], (entity) => {
+			addCounter += 1;
+		});
+
+		world.onRemove([Position], (entity) => {
+			removeCounter += 1;
+		});
+
+		const entity = world.spawn(Position);
+		expect(addCounter).toBe(1);
+
+		world.reset({ preserveSubscriptions: true });
+		expect(addCounter).toBe(1);
+		expect(removeCounter).toBe(0);
+
+		world.spawn(Position);
+		expect(addCounter).toBe(2);
+
+		entity.destroy();
+		expect(removeCounter).toBe(1);
 	});
 });


### PR DESCRIPTION
Adds some options the world reset method. For example, to preserve subscriptions to queries.