### PR TITLE
Fix world reset reactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,15 +446,8 @@ world.entities
 const id = world.id()
 
 // Resets the world as if it were just created
-// Options can be passed in to modify the reset behavior
-world.reset({
-  // Default false. If true, does not clear cached queries
-  preserveQueries: false 
-  // Default false. If true, does not clear cached traits
-  preserveTraits: false 
-  // Default false. If true, does not clear subscrptions, queries or traits
-  preserveSubscriptions: false 
-})
+// The world ID and reference is preserved
+world.reset()
 
 // Nukes the world and releases its ID
 world.destroy()

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -431,16 +431,4 @@ export class Query {
 			bitmask.changedTracker[eid] = 0;
 		}
 	}
-
-	clear(options: { preserveSubscriptions: boolean } = { preserveSubscriptions: false }) {
-		this.entities.clear();
-		this.toRemove.clear();
-
-		if (!options.preserveSubscriptions) {
-			this.addSubscriptions.clear();
-			this.removeSubscriptions.clear();
-		}
-
-		this.version++;
-	}
 }

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -89,42 +89,4 @@ describe('World', () => {
 		world.set(TimeOfDay, { hour: 1 });
 		expect(timeOfDay).toEqual({ hour: 1 });
 	});
-
-	it('should preserve subscriptions when reset with preserveSubscriptions', () => {
-		const world = createWorld();
-		const Position = trait({ x: 0, y: 0 });
-
-		let addCounter = 0;
-		let removeCounter = 0;
-
-		world.onAdd([Position], (entity) => {
-			addCounter += 1;
-		});
-
-		world.onRemove([Position], (entity) => {
-			removeCounter += 1;
-		});
-
-		const entity = world.spawn(Position);
-		expect(addCounter).toBe(1);
-
-		let results = world.query(Position);
-		expect(results.length).toBe(1);
-
-		world.reset({ preserveSubscriptions: true });
-		expect(addCounter).toBe(1);
-		expect(removeCounter).toBe(0);
-
-		results = world.query(Position);
-		expect(results.length).toBe(0);
-
-		world.spawn(Position);
-		expect(addCounter).toBe(2);
-
-		results = world.query(Position);
-		expect(results.length).toBe(1);
-
-		entity.destroy();
-		expect(removeCounter).toBe(1);
-	});
 });

--- a/packages/react/src/hooks/use-query.ts
+++ b/packages/react/src/hooks/use-query.ts
@@ -4,13 +4,14 @@ import { useWorld } from '../world/use-world';
 
 export function useQuery<T extends QueryParameter[]>(...parameters: T): QueryResult<T> {
 	const world = useWorld();
+	const [version, setVersion] = useState(0);
 
-	const [hash, initialVersion] = useMemo(() => {
+	const [hash, initialQueryVersion] = useMemo(() => {
 		const hash = cacheQuery(...parameters);
 		// Using internals to get the query data
 		const query = world[$internal].queriesHashMap.get(hash)!;
 		return [hash, query.version];
-	}, [parameters]);
+	}, [parameters, world]);
 
 	const [entities, setEntities] = useState<QueryResult<T>>(() => world.query(hash).sort());
 
@@ -27,7 +28,7 @@ export function useQuery<T extends QueryParameter[]>(...parameters: T): QueryRes
 		// Compare the initial version to the current version to
 		// see it the query has changed
 		const query = world[$internal].queriesHashMap.get(hash)!;
-		if (query.version !== initialVersion) {
+		if (query.version !== initialQueryVersion) {
 			setEntities(world.query(hash).sort());
 		}
 
@@ -35,7 +36,17 @@ export function useQuery<T extends QueryParameter[]>(...parameters: T): QueryRes
 			unsubAdd();
 			unsubRemove();
 		};
-	}, [world, hash]);
+	}, [world, hash, version]);
+
+	// Force reattaching event listeners when the world is reset
+	useEffect(() => {
+		const handler = () => setVersion((v) => v + 1);
+		world[$internal].resetSubscriptions.add(handler);
+
+		return () => {
+			world[$internal].resetSubscriptions.delete(handler);
+		};
+	}, [world]);
 
 	return entities;
 }

--- a/packages/react/src/world/use-world.ts
+++ b/packages/react/src/world/use-world.ts
@@ -2,5 +2,11 @@ import { useContext } from 'react';
 import { WorldContext } from './world-context';
 
 export function useWorld() {
-	return useContext(WorldContext);
+	const world = useContext(WorldContext);
+
+	if (!world) {
+		throw new Error('Koota: useWorld must be used within a WorldProvider');
+	}
+
+	return world;
 }

--- a/packages/react/tests/query.test.tsx
+++ b/packages/react/tests/query.test.tsx
@@ -102,11 +102,10 @@ describe('useQuery', () => {
 		// Spawn an initial entity
 		world.spawn(Position);
 
-		let entities: QueryResult<[typeof Position]> = null!;
 		let renderCount = 0;
 
 		function Test() {
-			entities = useQuery(Position);
+			useQuery(Position);
 			renderCount++;
 			return null;
 		}

--- a/packages/react/tests/trait.test.tsx
+++ b/packages/react/tests/trait.test.tsx
@@ -46,13 +46,6 @@ describe('useTrait', () => {
 
 		await act(async () => {
 			entity.set(Position, { x: 1, y: 1 });
-			await renderer!.update(
-				<StrictMode>
-					<WorldProvider world={world}>
-						<Test />
-					</WorldProvider>
-				</StrictMode>
-			);
 		});
 
 		expect(position).toEqual({ x: 1, y: 1 });
@@ -91,13 +84,6 @@ describe('useTrait', () => {
 
 		await act(async () => {
 			entity!.set(Position, { x: 1, y: 1 });
-			await renderer!.update(
-				<StrictMode>
-					<WorldProvider world={world}>
-						<Test />
-					</WorldProvider>
-				</StrictMode>
-			);
 		});
 
 		expect(position).toEqual({ x: 1, y: 1 });
@@ -129,14 +115,6 @@ describe('useTrait', () => {
 
 		await act(async () => {
 			world.set(TimeOfDay, { hour: 1 });
-
-			await renderer!.update(
-				<StrictMode>
-					<WorldProvider world={world}>
-						<Test />
-					</WorldProvider>
-				</StrictMode>
-			);
 		});
 
 		expect(timeOfDay).toEqual({ hour: 1 });
@@ -167,6 +145,8 @@ describe('useTrait', () => {
 
 		await act(async () => {
 			entity = world.spawn(Position);
+
+			// Force re-render
 			await renderer!.update(
 				<StrictMode>
 					<WorldProvider world={world}>
@@ -177,5 +157,37 @@ describe('useTrait', () => {
 		});
 
 		expect(position).toEqual({ x: 0, y: 0 });
+	});
+
+	it('reactively updates when the world is reset', async () => {
+		const entity = world.spawn(Position);
+		let position: TraitInstance<typeof Position> | undefined = undefined;
+
+		function Test() {
+			position = useTrait(entity, Position);
+			return null;
+		}
+
+		let renderer: any;
+
+		await act(async () => {
+			renderer = await ReactThreeTestRenderer.create(
+				<StrictMode>
+					<WorldProvider world={world}>
+						<Test />
+					</WorldProvider>
+				</StrictMode>
+			);
+
+			entity.set(Position, { x: 1, y: 1 });
+		});
+
+		expect(position).toEqual({ x: 1, y: 1 });
+
+		await act(async () => {
+			world.reset();
+		});
+
+		expect(position).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Remove the reset options and add an internal reset subscription API that `useQuery` hooks into for reactivity.