### PR TITLE
🐛  core: system traits get properly registered with new worlds

### DIFF
--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -155,6 +155,8 @@ export class Query {
 			...this.traitData.changed,
 		];
 
+		console.log('traitData', this.traitData);
+
 		// Create an array of all trait generations.
 		this.generations = this.traitData.all
 			.map((c) => c.generationId)

--- a/packages/core/src/query/utils/cache-query.ts
+++ b/packages/core/src/query/utils/cache-query.ts
@@ -9,8 +9,10 @@ export function cacheQuery<T extends QueryParameter[]>(...parameters: T): QueryH
 
 	for (const worldRef of universe.worlds) {
 		if (!worldRef) continue;
+
 		const world = worldRef.deref()!;
 		const ctx = world[$internal];
+
 		if (!ctx.queriesHashMap.has(hash)) {
 			const query = new Query(world, parameters);
 			ctx.queriesHashMap.set(hash, query);

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -68,6 +68,9 @@ export class World {
 			setTrackingMasks(this, i);
 		}
 
+		// Register system traits.
+		if (!ctx.traitData.has(IsExcluded)) registerTrait(this, IsExcluded);
+
 		// Create cached queries.
 		for (const [hash, parameters] of universe.cachedQueries) {
 			const query = new Query(this, parameters);

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -589,6 +589,13 @@ describe('Query', () => {
 		let entities = world.query(key);
 
 		expect(entities).toEqual([entityA]);
+
+		// Test caching before a world is created.
+		const world2 = createWorld();
+		const entityC = world2.spawn(Position, Name, IsActive);
+		const query2 = world2.query(key);
+
+		expect(query2).toEqual([entityC]);
 	});
 
 	it('should exclude entities with IsExcluded', () => {


### PR DESCRIPTION
This caused `cacheQuery` to fail when run before a world was created, among other possible bugs.