### PR TITLE
fix: emit "use strict" everywhere to thwart bad bundlers

### DIFF
--- a/packages/publish/tsup.config.ts
+++ b/packages/publish/tsup.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
 	entry: ['src/index.ts', 'src/react.ts'],
 	format: ['esm', 'cjs'],
+	esbuildOptions: (options, { format }) => {
+		options.banner = format === 'esm' ? {
+			js: '\"use strict\";',
+		} : undefined;
+	},
 	dts: {
 		resolve: true,
 	},

--- a/packages/publish/tsup.config.ts
+++ b/packages/publish/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 	// Not all bundlers and frameworks are capable of correctly transforming esm
 	// to cjs output and koota requires strict mode to be enabled for the code to 
 	// be sound. The "use strict" directive has no ill effect when running in an
-	// esm environment, while bringing the extra guarantee of ensuing strict mode
+	// esm environment, while bringing the extra guarantee of ensuring strict mode
 	// is used in non-conformant environments.
 	// See https://262.ecma-international.org/5.1/#sec-C for more details.
 	esbuildOptions: (options, { format }) => {

--- a/packages/publish/tsup.config.ts
+++ b/packages/publish/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	format: ['esm', 'cjs'],
 	// Force emitting "use strict" for ESM output
 	// Not all bundlers and frameworks are capable of correctly transforming esm
-	// to cjs output and koota requires strict mode to be enabled for the code to 
+	// to cjs output and koota requires strict mode to be enabled for the code to
 	// be sound. The "use strict" directive has no ill effect when running in an
 	// esm environment, while bringing the extra guarantee of ensuring strict mode
 	// is used in non-conformant environments.

--- a/packages/publish/tsup.config.ts
+++ b/packages/publish/tsup.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
 	entry: ['src/index.ts', 'src/react.ts'],
 	format: ['esm', 'cjs'],
+	// Force emitting "use strict" for ESM output
+	// Not all bundlers and frameworks are capable of correctly transforming esm
+	// to cjs output and koota requires strict mode to be enabled for the code to 
+	// be sound. The "use strict" directive has no ill effect when running in an
+	// esm environment, while bringing the extra guarantee of ensuing strict mode
+	// is used in non-conformant environments.
+	// See https://262.ecma-international.org/5.1/#sec-C for more details.
 	esbuildOptions: (options, { format }) => {
 		options.banner = format === 'esm' ? {
 			js: '\"use strict\";',


### PR DESCRIPTION
When running vite as my bundler, koota is running under strict mode.
When using metro with expo dom components koota is not running under strict mode.

When `this` is evaluated in Number.prototype.add in strict mode it will be a number.
When `this` is evaluated in Number.prototype.add without strict mode, it is coerced into an object, and that object is then used as the lookup in the Set where that object is not in the Set, the valueOf that object is.

See: https://262.ecma-international.org/5.1/#sec-C
![image](https://github.com/user-attachments/assets/e2fa460e-01fb-4818-a5bc-4f1f7703b17e)

Philosophcally it is a slightly painful pr to make, however, if bundlers in 2025 are going to run esm code without strict mode enabled, we should help them to have a chance.