### PR TITLE
Add missing exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,6 @@ entity.set(Position, { x: 10, y: 20 });
 entity.remove(Position);
 ```
 
-### Query all entities
-
-To get al queryable entities you simply query with not paramerters. Note, that not all entities are queryable. Any entity that has `IsExcluded` will not be able to be queried. This is used in Koota to exclude world entities, for example, but maybe used for other system level entities in the future. To get all entities regardless, use `world.entities`.
-
 ```js
 // Returns all queryable entities
 const allQueryableEntities = world.query()
@@ -365,7 +361,7 @@ world.query(Position, Velocity, Mass)
   });
 ```
 
-### Modifying trait stores direclty
+### Modifying trait stores directly
 
 For performance-critical operations, you can modify trait stores directly using the `useStore` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. All stores are structure of arrays for performance purposes.
 
@@ -381,30 +377,6 @@ world.query(Position, Velocity).useStore(([position, velocity], entities) => {
         position.y[eid] += velocity.y[eid] * delta;
     }
 });
-```
-
-### Caching queries
-
-Inline queries are great for readability and are optimized to be as fast as possible, but there is still some small overhead in hashing the query each time it is called.
-
-```js
-// Every time this query runs a hash for the query parameters (Position, Velocity) 
-// is created and then used to get the cached query internally
-function updateMovement(world) {
-  world.query(Position, Velocity).updateEach(([pos, vel]) => { })
-}
-```
-
-While this is not likely to be a bottleneck in your code compared to the actual update function, if you want to save these CPU cycles you can cache the query ahead of time and use the returned key. This will have the additional effect of creating the internal query immediately on a worlds, otherwise it will get created the first time it is run.
-
-```js
-// The internal query is created immediately before it is invoked
-const movementQuery = cacheQuery(Position, Velocity)
-
-// They query key is hashed ahead of time and we just use it
-function updateMovement(world) {
-  world.query(movementQuery).updateEach(([pos, vel]) => { })
-}
 ```
 
 ### Query tips for the curious
@@ -563,6 +535,12 @@ const id = entity.id()
 entity.destroy()
 ```
 
+For introspection, `unpackEntity` can be used to get all of the encoded values. This can be useful for debugging.
+
+```js
+const { entityId, generation, worldId } = unpackEntity(entity)
+```
+
 ### Trait
 
 A trait is a specific block of data. They are added to entities to build up its overall data signature. If you are familiar with ECS, it is our version of a component. It is called a trait instead to not get confused with React or web components. 
@@ -622,7 +600,7 @@ const store = {
 
 #### Array of Structures (AoS) - Callback-based traits
 
-When using a callback, each entity's trait data is stored as an object in an array. This is best used for compatibiilty with third party libraries like Three, or class instnaces in general.
+When using a callback, each entity's trait data is stored as an object in an array. This is best used for compatibility with third party libraries like Three, or class instances in general.
 
 ```js
 const Velocity = trait(() => ({ x: 0, y: 0, z: 0 }));
@@ -677,6 +655,66 @@ const Attacker = trait<Pick<AttackerSchema, keyof AttackerSchema>>({
   stages: null,
   startedAt: null,
 })
+```
+
+#### Accessing the store directly
+
+The store can be accessed with `getStore`, but this low-level access is risky as it bypasses Koota's guard rails. However, this can be useful for debugging where direct introspection of the store is needed. For direct store mutations, use the [`useStore` API](#modifying-trait-stores-direclty) instead.
+
+```js
+// Returns SoA or AoS depending on the trait
+const positions = getStore(world, Position) 
+```
+
+### Query
+
+A Koota query is a lot like a database query. Parameters define how to find entities and efficiently process them in batches. Queries are the primary way to update and transform your app state, similar to how you'd use SQL to filter and modify database records.
+
+### Caching queries
+
+Inline queries are great for readability and are optimized to be as fast as possible, but there is still some small overhead in hashing the query each time it is called.
+
+```js
+// Every time this query runs a hash for the query parameters (Position, Velocity) 
+// is created and then used to get the cached query internally
+function updateMovement(world) {
+  world.query(Position, Velocity).updateEach(([pos, vel]) => { })
+}
+```
+
+While this is not likely to be a bottleneck in your code compared to the actual update function, if you want to save these CPU cycles you can cache the query ahead of time and use the returned key. This will have the additional effect of creating the internal query immediately on a worlds, otherwise it will get created the first time it is run.
+
+```js
+// The internal query is created immediately before it is invoked
+const movementQuery = cacheQuery(Position, Velocity)
+
+// They query key is hashed ahead of time and we just use it
+function updateMovement(world) {
+  world.query(movementQuery).updateEach(([pos, vel]) => { })
+}
+```
+
+### Query all entities
+
+To get all queryable entities you simply query with no parameters. 
+
+```js
+const allEntities = world.query()
+```
+
+This differs from `world.entities` which includes all entities, even system ones. Koota excludes its internal system entities from queries to keep userland queries from being polluted.
+
+#### Excluding entities from queries
+
+Any entity can be excluded from queries by adding the built-in tag `IsExcluded` to it. System entities get this tag added to them so that they do not interfere with the app.
+
+```js
+const entity = world.spawn(Position)
+// This entity can no longer be queried
+entity.add(IsExcluded)
+
+const entities = world.query(Position)
+entities.includes(entity) // This will always be false
 ```
 
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { createWorld } from './world/world';
-export { trait } from './trait/trait';
+export { trait, getStore } from './trait/trait';
 export { createAdded } from './query/modifiers/added';
 export { createRemoved } from './query/modifiers/removed';
 export { createChanged } from './query/modifiers/changed';
@@ -10,6 +10,7 @@ export { cacheQuery } from './query/utils/cache-query';
 export { relation, Pair, Wildcard } from './relation/relation';
 export { $internal } from './common';
 export { createActions } from './actions/create-actions';
+export { IsExcluded } from './query/query';
 
 // Export types
 export * from './trait/types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,21 +1,22 @@
-export { createWorld } from './world/world';
-export { trait, getStore } from './trait/trait';
+export { createActions } from './actions/create-actions';
+export { $internal } from './common';
+export { unpackEntity } from './entity/utils/pack-entity';
 export { createAdded } from './query/modifiers/added';
-export { createRemoved } from './query/modifiers/removed';
 export { createChanged } from './query/modifiers/changed';
 export { Not } from './query/modifiers/not';
 export { Or } from './query/modifiers/or';
-export { universe } from './universe/universe';
-export { cacheQuery } from './query/utils/cache-query';
-export { relation, Pair, Wildcard } from './relation/relation';
-export { $internal } from './common';
-export { createActions } from './actions/create-actions';
+export { createRemoved } from './query/modifiers/removed';
 export { IsExcluded } from './query/query';
+export { cacheQuery } from './query/utils/cache-query';
+export { Pair, relation, Wildcard } from './relation/relation';
+export { getStore, trait } from './trait/trait';
+export { universe } from './universe/universe';
+export { createWorld } from './world/world';
 
 // Export types
-export * from './trait/types';
+export * from './actions/types';
 export * from './entity/types';
 export * from './query/types';
 export * from './relation/types';
-export * from './actions/types';
+export * from './trait/types';
 export type { World } from './world/world';

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createWorld, trait } from '../src';
-import { createActions } from '../src/actions/create-actions';
+import { createActions, createWorld, trait } from '../src';
 
 const IsPlayer = trait();
 

--- a/packages/core/tests/entity.test.ts
+++ b/packages/core/tests/entity.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
-import { createWorld, trait, getStore, type Entity } from '../src';
-import { unpackEntity } from '../src/entity/utils/pack-entity';
+import { createWorld, getStore, trait, unpackEntity, type Entity } from '../src';
 
 const Foo = trait();
 const Bar = trait({ value: 0 });

--- a/packages/core/tests/entity.test.ts
+++ b/packages/core/tests/entity.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
-import { createWorld } from '../src';
-import { trait, getStore } from '../src/trait/trait';
-import { Entity } from '../src/entity/types';
+import { createWorld, trait, getStore, type Entity } from '../src';
 import { unpackEntity } from '../src/entity/utils/pack-entity';
 
 const Foo = trait();

--- a/packages/core/tests/query-modifiers.test.ts
+++ b/packages/core/tests/query-modifiers.test.ts
@@ -1,13 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { cacheQuery, createWorld } from '../src';
-import { $internal } from '../src/common';
-import { createAdded } from '../src/query/modifiers/added';
-import { createChanged } from '../src/query/modifiers/changed';
-import { Not } from '../src/query/modifiers/not';
-import { Or } from '../src/query/modifiers/or';
-import { createRemoved } from '../src/query/modifiers/removed';
-import { IsExcluded } from '../src/query/query';
-import { getStore, trait } from '../src/trait/trait';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	$internal,
+	createAdded,
+	createChanged,
+	createRemoved,
+	createWorld,
+	getStore,
+	Not,
+	trait,
+} from '../src';
 
 const Position = trait({ x: 0, y: 0 });
 const Name = trait({ name: 'name' });

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -1,13 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { cacheQuery, createWorld } from '../src';
-import { $internal } from '../src/common';
-import { createAdded } from '../src/query/modifiers/added';
-import { createChanged } from '../src/query/modifiers/changed';
-import { Not } from '../src/query/modifiers/not';
-import { Or } from '../src/query/modifiers/or';
-import { createRemoved } from '../src/query/modifiers/removed';
-import { IsExcluded } from '../src/query/query';
-import { getStore, trait } from '../src/trait/trait';
+import { $internal, cacheQuery, createWorld, IsExcluded, Not, Or, trait } from '../src';
 
 const Position = trait({ x: 0, y: 0 });
 const Name = trait({ name: 'name' });

--- a/packages/core/tests/relation.test.ts
+++ b/packages/core/tests/relation.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createWorld } from '../src';
-import { relation, Wildcard } from '../src/relation/relation';
+import { createWorld, relation, Wildcard } from '../src';
 
 describe('Relation', () => {
 	const world = createWorld();

--- a/packages/core/tests/trait.test.ts
+++ b/packages/core/tests/trait.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createWorld, Entity } from '../src';
-import { $internal } from '../src/common';
-import { getStore, registerTrait, trait } from '../src/trait/trait';
+import { createWorld, type Entity, getStore, trait } from '../src';
 
 class TestClass {
 	constructor(public name = 'TestClass') {}
@@ -28,17 +26,6 @@ describe('Trait', () => {
 
 		expect(Object.keys(Test)).toEqual(['schema']);
 		expect(typeof Test === 'function').toBe(true);
-	});
-
-	it('should register a trait', () => {
-		const Position = trait({ x: 0, y: 0 });
-		registerTrait(world, Position);
-
-		const ctx = world[$internal];
-		// Has sytem traits registered by default.
-		expect(world.traits.size).toBe(2);
-		expect(ctx.traitData.size).toBe(2);
-		expect(ctx.traitData.get(Position)).toBeDefined();
 	});
 
 	it('should add and remove traits to an entity', () => {
@@ -241,7 +228,7 @@ describe('Trait', () => {
 
 		entity.add(Position({ x: 1, y: 2 }));
 		expect(addCb).toHaveBeenCalledTimes(1);
-		
+
 		entity.remove(Position);
 		expect(removeCb).toHaveBeenCalledTimes(1);
 	});

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createWorld, TraitInstance } from '../src';
-import { trait } from '../src/trait/trait';
-import { universe } from '../src/universe/universe';
+import { createWorld, trait, TraitInstance, universe } from '../src';
 
 describe('World', () => {
 	beforeEach(() => {
@@ -9,9 +7,8 @@ describe('World', () => {
 	});
 
 	it('should create a world', () => {
-		const world = createWorld();
-
 		// World inits on creation.
+		const world = createWorld();
 
 		expect(world.isInitialized).toBe(true);
 		expect(world.id).toBe(0);


### PR DESCRIPTION
Adds missing exports found in tests, `unpackEntity`, `getStore` and `IsExcluded.` Also makes the tests import from index to make sure it only tests public APIs.