### PR TITLE
fix: ensure entities are only destroyed when present

### DIFF
--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -128,7 +128,13 @@ export class World {
 		const ctx = this[$internal];
 
 		// Destroy all entities so any cleanup is done.
-		this.entities.forEach((entity) => destroyEntity(this, entity));
+		this.entities.forEach((entity) => {
+			// Some relations may have caused the entity to be destroyed before
+			// we get to them in the loop.
+			if (this.has(entity)) {
+				destroyEntity(this, entity)
+			}
+		});
 
 		ctx.entityIndex = createEntityIndex(this.#id);
 		ctx.entityTraits.clear();

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createWorld, TraitInstance } from '../src';
+import { createWorld, relation, TraitInstance } from '../src';
 import { trait } from '../src/trait/trait';
 import { universe } from '../src/universe/universe';
 
@@ -76,6 +76,24 @@ describe('World', () => {
 		world.remove(Time);
 		expect(world.has(Time)).toBe(false);
 	});
+
+	it('should remove all without exception, even with auto-remove relations', () => {
+		const Node = trait();
+		const ChildOf = relation({ autoRemoveTarget: true, exclusive: true });
+
+		const world = createWorld();
+
+		// Create a parent node and a child node.
+		const parentNode = world.spawn(Node)
+		world.spawn(Node, ChildOf(parentNode));
+
+		// Expect this to not throw, since the ChildOf relation will automatically
+		// remove the child node when the parent node is destroyed first.
+		expect(() => world.reset()).not.toThrow();
+
+		// Always has one entity that is the world itself.
+		expect(world.entities.length).toBe(1);
+	})
 
 	it('should observe traits', () => {
 		const TimeOfDay = trait({ hour: 0 });

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -27,6 +27,24 @@ describe('World', () => {
 		expect(world.entities.length).toBe(1);
 	});
 
+	it('reset should remove entities with auto-remove relations', () => {
+		const Node = trait();
+		const ChildOf = relation({ autoRemoveTarget: true, exclusive: true });
+
+		const world = createWorld();
+
+		// Create a parent node and a child node.
+		const parentNode = world.spawn(Node);
+		world.spawn(Node, ChildOf(parentNode));
+
+		// Expect this to not throw, since the ChildOf relation will automatically
+		// remove the child node when the parent node is destroyed first.
+		expect(() => world.reset()).not.toThrow();
+
+		// Always has one entity that is the world itself.
+		expect(world.entities.length).toBe(1);
+	});
+
 	it('errors if more than 16 worlds are created', () => {
 		for (let i = 0; i < 16; i++) {
 			createWorld();
@@ -76,24 +94,6 @@ describe('World', () => {
 		world.remove(Time);
 		expect(world.has(Time)).toBe(false);
 	});
-
-	it('should remove all without exception, even with auto-remove relations', () => {
-		const Node = trait();
-		const ChildOf = relation({ autoRemoveTarget: true, exclusive: true });
-
-		const world = createWorld();
-
-		// Create a parent node and a child node.
-		const parentNode = world.spawn(Node)
-		world.spawn(Node, ChildOf(parentNode));
-
-		// Expect this to not throw, since the ChildOf relation will automatically
-		// remove the child node when the parent node is destroyed first.
-		expect(() => world.reset()).not.toThrow();
-
-		// Always has one entity that is the world itself.
-		expect(world.entities.length).toBe(1);
-	})
 
 	it('should observe traits', () => {
 		const TimeOfDay = trait({ hour: 0 });


### PR DESCRIPTION
This is fixing a bug in the `world.reset()` method when we have relationships with auto-remove targets.