### PR TITLE
fix: only update a Changed query when the tracked trait is changed

### DIFF
--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -43,6 +43,8 @@ export function setChanged(world: World, entity: Entity, trait: Trait) {
 	for (const query of data.queries) {
 		// If the query has no changed modifiers, continue.
 		if (!query.hasChangedModifiers) continue;
+		// If the trait is not part of a Changed modifier in this query, continue.
+		if (!query.changedTraits.has(trait)) continue;
 
 		// Check if the entity matches the query.
 		let match = query.check(world, entity, { type: 'change', traitData: data });

--- a/packages/core/tests/query-modifiers.test.ts
+++ b/packages/core/tests/query-modifiers.test.ts
@@ -463,14 +463,17 @@ describe('Query modifiers', () => {
 		expect(entities2.length).toBe(1);
 	});
 
-	it.fails('should only update a Changed query when the tracked trait is changed', () => {
-		const entity = world.spawn(Foo, Bar);
+	it('should only update a Changed query when the tracked trait is changed', () => {
 		const Changed = createChanged();
+
+		const entity = world.spawn(Foo, Bar);
+
+		expect(world.queryFirst(Foo, Changed(Bar))).toBeUndefined();
 
 		entity.changed(Bar);
 		expect(world.queryFirst(Foo, Changed(Bar))).toBe(entity);
 
 		entity.changed(Foo);
-		expect(world.queryFirst(Foo, Changed(Bar))).toBeUndefined;
+		expect(world.queryFirst(Foo, Changed(Bar))).toBeUndefined();
 	});
 });


### PR DESCRIPTION
This PR updates `setChanged` logic to prevent unrelated traits from incorrectly updating state of queries with `Changed` modifiers