### PR TITLE
Reset bit masks after executing tracking queries

### DIFF
--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -24,7 +24,13 @@ export function createQueryResult<T extends QueryParameter[]>(
 	query.commitRemovals(world);
 	const entities = query.entities.dense.slice() as Entity[];
 	// Clear so it can accumulate again.
-	if (query.isTracking) query.entities.clear();
+	if (query.isTracking) {
+		query.entities.clear();
+
+		for (const eid of entities) {
+			query.resetTrackingBitmasks(eid);
+		}
+	}
 
 	const stores: Store<any>[] = [];
 	const traits: Trait[] = [];

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -23,10 +23,12 @@ export function createQueryResult<T extends QueryParameter[]>(
 ): QueryResult<T> {
 	query.commitRemovals(world);
 	const entities = query.entities.dense.slice() as Entity[];
+
 	// Clear so it can accumulate again.
 	if (query.isTracking) {
 		query.entities.clear();
 
+		// @todo: Need to improve the performance of this loop.
 		for (const eid of entities) {
 			query.resetTrackingBitmasks(eid);
 		}

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -290,7 +290,13 @@ export class Query {
 		const result = this.entities.dense.slice();
 
 		// Clear so it can accumulate again.
-		if (this.isTracking) this.entities.clear();
+		if (this.isTracking) {
+			this.entities.clear();
+
+			for (const eid of result) {
+				this.resetTrackingBitmasks(eid);
+			}
+		}
 
 		return result as Entity[];
 	}

--- a/packages/core/tests/query-modifiers.test.ts
+++ b/packages/core/tests/query-modifiers.test.ts
@@ -378,7 +378,7 @@ describe('Query modifiers', () => {
 		entityA.remove(Foo);
 		entityA.add(Foo);
 		entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities[0]).toBe(entityA);
+		expect(entities.length).toBe(0);
 
 		// Add Foo to entityB and remove Bar.
 		// This entity should now match the query.
@@ -460,7 +460,7 @@ describe('Query modifiers', () => {
 		expect(entities2.length).toBe(1);
 	});
 
-	it.fails('should only update a Changed query when the tracked trait is changed', () => {
+	it('should only update a Changed query when the tracked trait is changed', () => {
 		const entity = world.spawn(Foo, Bar);
 
 		const Changed = createChanged();
@@ -476,7 +476,7 @@ describe('Query modifiers', () => {
 	});
 
 	// @see https://github.com/pmndrs/koota/issues/115
-	it.fails('should not trigger Changed query when removing a different trait', () => {
+	it('should not trigger Changed query when removing a different trait', () => {
 		const Changed = createChanged();
 		const entity = world.spawn(Position);
 


### PR DESCRIPTION
This PR fixes a couple of bugs by resetting bit masks for entities returned from tracking queries