### PR TITLE
feat: remove all relation targets with a wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,35 @@ const containsAnything = world.query(Contains('*')) // Returns [inventory, chest
 const relatesToGold = world.query(Wildcard(gold)) // Returns [inventory, chest, dwarf]
 ```
 
+#### Removing relationships
+
+A relationship is with a specific target entity, so we need to likewise remove relationships for specific entities.
+
+```js
+// Add a specific relation
+player.add(Likes(apple))
+player.add(Likes(banana))
+
+// Remove that same relation
+player.remove(Likes(apple))
+
+player.has(apple) // false
+player.has(banana) // true
+```
+
+However, a wildcard can be used to remove all relationships of a kind, for all targets.
+
+```js
+player.add(Likes(apple))
+player.add(Likes(banana))
+
+// Remove all Likes relations
+player.remove(Likes('*'))
+
+player.has(apple) // false
+player.has(banana) // false
+```
+
 ### Query modifiers
 
 Modifiers are used to filter query results enabling powerful patterns. All modifiers can be mixed together.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ const relatesToGold = world.query(Wildcard(gold)) // Returns [inventory, chest, 
 
 #### Removing relationships
 
-A relationship is with a specific target entity, so we need to likewise remove relationships for specific entities.
+A relationship targets a specific entity, so we need to likewise remove relationships with specific entities.
 
 ```js
 // Add a specific relation
@@ -233,7 +233,7 @@ player.has(apple) // false
 player.has(banana) // true
 ```
 
-However, a wildcard can be used to remove all relationships of a kind, for all targets.
+However, a wildcard can be used to remove all relationships of a kind — for all targets — from an entity.
 
 ```js
 player.add(Likes(apple))

--- a/packages/core/src/trait/trait.ts
+++ b/packages/core/src/trait/trait.ts
@@ -215,6 +215,19 @@ export function removeTrait(world: World, entity: Entity, ...traits: Trait[]) {
 			if (otherTargets.length === 0) {
 				removeTrait(world, entity, Pair(relation, Wildcard));
 			}
+
+			// Removing a relation with a wildcard should also remove every target of that relation.
+			if (
+				traitCtx.isPairTrait &&
+				traitCtx.pairTarget === Wildcard &&
+				traitCtx.relation !== Wildcard
+			) {
+				const relation = traitCtx.relation!;
+				const targets = getRelationTargets(world, relation, entity);
+				for (const target of targets) {
+					removeTrait(world, entity, relation(target));
+				}
+			}
 		}
 	}
 }

--- a/packages/core/src/trait/trait.ts
+++ b/packages/core/src/trait/trait.ts
@@ -216,7 +216,7 @@ export function removeTrait(world: World, entity: Entity, ...traits: Trait[]) {
 				removeTrait(world, entity, Pair(relation, Wildcard));
 			}
 
-			// Removing a relation with a wildcard should also remove every target of that relation.
+			// Removing a relation with a wildcard should also remove every target for that relation.
 			if (
 				traitCtx.isPairTrait &&
 				traitCtx.pairTarget === Wildcard &&

--- a/packages/core/tests/relation.test.ts
+++ b/packages/core/tests/relation.test.ts
@@ -57,6 +57,12 @@ describe('Relation', () => {
 		expect(target).toBe(player);
 		expect(goblin.has(Targeting(player))).toBe(true);
 		expect(goblin.has(Targeting(guard))).toBe(false);
+
+		// Remove the target and check if the target is removed
+		goblin.remove(Targeting(player));
+		target = goblin.targetFor(Targeting);
+
+		expect(target).toBe(undefined);
 	});
 
 	it('should auto remove target and its descendants', () => {
@@ -209,5 +215,21 @@ describe('Relation', () => {
 		expect(world.has(durian)).toBe(false);
 		expect(world.has(apple)).toBe(true);
 		expect(world.has(cherry)).toBe(true);
+	});
+
+	it('should remove all relations with a wildcard', () => {
+		const Likes = relation();
+
+		const person = world.spawn();
+		const apple = world.spawn();
+		const banana = world.spawn();
+
+		person.add(Likes(apple));
+		person.add(Likes(banana));
+
+		person.remove(Likes('*'));
+
+		expect(person.has(Likes(apple))).toBe(false);
+		expect(person.has(Likes(banana))).toBe(false);
 	});
 });

--- a/packages/publish/tests/core/trait.test.ts
+++ b/packages/publish/tests/core/trait.test.ts
@@ -12,6 +12,7 @@ const Test = trait({
 	bool: true,
 	arr: () => ['a', 'b', 'c'],
 	class: () => new TestClass(),
+	bigInt: 1n,
 });
 
 describe('Trait', () => {


### PR DESCRIPTION
For example:

```js
player.add(Likes(apple))
player.add(Likes(banana))

// Remove all Likes relations
player.remove(Likes('*'))

player.has(apple) // false
player.has(banana) // false
```