### PR TITLE
✨ core: nested schema objects

### DIFF
--- a/packages/core/src/trait/utils/create-store.ts
+++ b/packages/core/src/trait/utils/create-store.ts
@@ -1,3 +1,4 @@
+import { isObject } from '../../utils/is';
 import type { Schema, Store } from '../types';
 
 export function createStore<T extends Schema>(schema: T): Store<T> {
@@ -7,7 +8,13 @@ export function createStore<T extends Schema>(schema: T): Store<T> {
 		const store = {} as any;
 
 		for (const key in schema) {
-			store[key] = [];
+			const value = schema[key];
+
+			if (isObject(value)) {
+				store[key] = createStore(value as Schema);
+			} else {
+				store[key] = [];
+			}
 
 			// Legacy code for TypedArray support -- MT in particular.
 			// I will revist this later.

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -1,0 +1,3 @@
+export function isObject(value: any): boolean {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/core/tests/trait.test.ts
+++ b/packages/core/tests/trait.test.ts
@@ -13,6 +13,7 @@ const Test = trait({
 	arr: () => ['a', 'b', 'c'],
 	class: () => new TestClass(),
 	bigInt: 1n,
+	object: { x: 0, y: 0 },
 });
 
 describe('Trait', () => {
@@ -64,14 +65,18 @@ describe('Trait', () => {
 		const entity = world.spawn();
 
 		entity.add(Test);
-		const test = entity.get(Test);
+		const test = entity.get(Test)!;
 
 		expect(test).toMatchObject({
 			current: 1,
 			test: 'hello',
 			bool: true,
 			arr: ['a', 'b', 'c'],
+			object: { x: 0, y: 0 },
 		});
+
+		// Nested schema objects should have their own stores created.
+		expect(Test.schema.object).not.toBe(test.object);
 	});
 
 	it('should override defaults with params', () => {


### PR DESCRIPTION
Currently if you use nested objects in a schema the object will simply be shared between all instances of that trait data. To make it unique an initializer is necessary.

```js
// Every instance of the force trait shares the same object reference
const Forces = trait({
    coherence: { x: 0, y: 0, z: 0 },
    separation: { x: 0, y: 0, z: 0 },
    alignment: { x: 0, y: 0, z: 0 },
    avoidEdges: { x: 0, y: 0, z: 0 },
});

// To make it unique, we explicitly use an initializer
const Forces = trait({
    coherence: () => ({ x: 0, y: 0, z: 0 }),
    separation: () => ({ x: 0, y: 0, z: 0 }),
    alignment: () => ({ x: 0, y: 0, z: 0 }),
    avoidEdges: () => ({ x: 0, y: 0, z: 0 }),
});
```

However, I am not sure I like this being the default behavior. I am leaning towards making it so **all** schema objects are read the same no matter their nesting. IE all schema objects are transformed into SoA stores. In this case if you wanted to share an object you use an initializer to have your own store logic.

Follow up question: Should the same be true for arrays? 
