### PR TITLE
Chore  three-stdlib

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,11 +60,23 @@ importers:
         specifier: latest
         version: 5.8.3
 
-  .config/oxlint: {}
+  .config/oxlint:
+    dependencies:
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
 
-  .config/prettier: {}
+  .config/prettier:
+    dependencies:
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
 
-  .config/typescript: {}
+  .config/typescript:
+    dependencies:
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
 
   benches/apps/add-remove:
     dependencies:
@@ -83,6 +95,9 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -102,6 +117,9 @@ importers:
       '@sim/bench-tools':
         specifier: workspace:*
         version: link:../../sims/bench-tools
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -133,6 +151,9 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -170,6 +191,9 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -207,6 +231,9 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -256,6 +283,9 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -290,6 +320,9 @@ importers:
       koota:
         specifier: workspace:*
         version: link:../../../packages/publish
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -300,6 +333,9 @@ importers:
 
   benches/sims/bench-tools:
     dependencies:
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
       web-worker:
         specifier: ^1.3.0
         version: 1.5.0
@@ -319,6 +355,9 @@ importers:
       koota:
         specifier: workspace:*
         version: link:../../../packages/publish
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -328,6 +367,10 @@ importers:
         version: link:../../../.config/typescript
 
   packages/core:
+    dependencies:
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -343,7 +386,10 @@ importers:
     dependencies:
       '@types/react':
         specifier: '>=18.0.0'
-        version: 19.0.8
+        version: 19.1.6
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -356,7 +402,7 @@ importers:
         version: link:../react
       '@testing-library/react':
         specifier: ^16.2.0
-        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       esbuild-plugin-inline-functions:
         specifier: 'catalog:'
         version: 0.2.0(@babel/parser@7.26.8)(@babel/traverse@7.26.8)(@babel/types@7.26.8)(@types/node@24.0.1)(jsdom@26.0.0)(tsx@4.20.3)
@@ -378,6 +424,9 @@ importers:
       '@koota/core':
         specifier: workspace:*
         version: link:../core
+      three-stdlib:
+        specifier: 2.35.16
+        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -1431,9 +1480,6 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
-  '@types/react@19.0.8':
-    resolution: {integrity: sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==}
-
   '@types/react@19.1.6':
     resolution: {integrity: sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==}
 
@@ -2239,8 +2285,8 @@ packages:
     peerDependencies:
       three: '>= 0.159.0'
 
-  three-stdlib@2.35.13:
-    resolution: {integrity: sha512-AbXVObkM0OFCKX0r4VmHguGTdebiUQA+Yl+4VNta1wC158gwY86tCkjp2LFfmABtjYJhdK6aP13wlLtxZyLMAA==}
+  three-stdlib@2.35.16:
+    resolution: {integrity: sha512-TgXRLSC3rcsiYNgHaz4zVBvgwTxA+u2wdueXAZeNL5UxXbzgadx03JxSaGisutwY1Fkm9349IizFsxNtOwJVcg==}
     peerDependencies:
       three: '>=0.128.0'
 
@@ -3071,7 +3117,7 @@ snapshots:
       suspend-react: 0.1.3(react@19.1.0)
       three: 0.177.0
       three-mesh-bvh: 0.8.3(three@0.177.0)
-      three-stdlib: 2.35.13(three@0.177.0)
+      three-stdlib: 2.35.16(three@0.177.0)
       troika-three-text: 0.52.4(three@0.177.0)
       tunnel-rat: 0.1.2(@types/react@19.1.6)(react@19.1.0)
       use-sync-external-store: 1.4.0(react@19.1.0)
@@ -3286,15 +3332,15 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.26.7
       '@testing-library/dom': 10.4.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
-      '@types/react': 19.0.8
-      '@types/react-dom': 19.1.6(@types/react@19.0.8)
+      '@types/react': 19.1.6
+      '@types/react-dom': 19.1.6(@types/react@19.1.6)
 
   '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -3351,11 +3397,6 @@ snapshots:
 
   '@types/offscreencanvas@2019.7.3': {}
 
-  '@types/react-dom@19.1.6(@types/react@19.0.8)':
-    dependencies:
-      '@types/react': 19.0.8
-    optional: true
-
   '@types/react-dom@19.1.6(@types/react@19.1.6)':
     dependencies:
       '@types/react': 19.1.6
@@ -3363,10 +3404,6 @@ snapshots:
   '@types/react-reconciler@0.28.9(@types/react@19.1.6)':
     dependencies:
       '@types/react': 19.1.6
-
-  '@types/react@19.0.8':
-    dependencies:
-      csstype: 3.1.3
 
   '@types/react@19.1.6':
     dependencies:
@@ -4230,7 +4267,7 @@ snapshots:
     dependencies:
       three: 0.177.0
 
-  three-stdlib@2.35.13(three@0.177.0):
+  three-stdlib@2.35.16(three@0.177.0):
     dependencies:
       '@types/draco3d': 1.4.10
       '@types/offscreencanvas': 2019.7.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,23 +60,11 @@ importers:
         specifier: latest
         version: 5.8.3
 
-  .config/oxlint:
-    dependencies:
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
+  .config/oxlint: {}
 
-  .config/prettier:
-    dependencies:
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
+  .config/prettier: {}
 
-  .config/typescript:
-    dependencies:
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
+  .config/typescript: {}
 
   benches/apps/add-remove:
     dependencies:
@@ -95,9 +83,6 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -117,9 +102,6 @@ importers:
       '@sim/bench-tools':
         specifier: workspace:*
         version: link:../../sims/bench-tools
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -151,9 +133,6 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -191,9 +170,6 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -231,9 +207,6 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -283,9 +256,6 @@ importers:
       three:
         specifier: 'catalog:'
         version: 0.177.0
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -320,9 +290,6 @@ importers:
       koota:
         specifier: workspace:*
         version: link:../../../packages/publish
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -333,9 +300,6 @@ importers:
 
   benches/sims/bench-tools:
     dependencies:
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
       web-worker:
         specifier: ^1.3.0
         version: 1.5.0
@@ -355,9 +319,6 @@ importers:
       koota:
         specifier: workspace:*
         version: link:../../../packages/publish
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -367,10 +328,6 @@ importers:
         version: link:../../../.config/typescript
 
   packages/core:
-    dependencies:
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -387,9 +344,6 @@ importers:
       '@types/react':
         specifier: '>=18.0.0'
         version: 19.1.6
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -424,9 +378,6 @@ importers:
       '@koota/core':
         specifier: workspace:*
         version: link:../core
-      three-stdlib:
-        specifier: 2.35.16
-        version: 2.35.16(three@0.177.0)
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*


### PR DESCRIPTION
Dep tree had a mismatch, see: https://github.com/mrdoob/three.js/pull/30934 and https://github.com/pmndrs/three-stdlib/pull/419. Having the older stdlib made freshly  cloned/installed repo fail when running commands such as `pnpm run app boids`

I opted to just bump the stdlib to the version that had the fix, rather than the latest version available as that felt safer 😛

Note also that some lines re react types got updated as well, which makes the diff less clean than I would have liked but these appear to be in keeping with the dep specification. 

Running with this diff allowed me to run the examples on a new machine without error, as I was able to previously.

Thanks!
