### PR TITLE
fix typo into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ return (
 )
 ```
 
-### `usQueryFirst`
+### `useQueryFirst`
 
 Works like `useQuery` but only returns the first result. Can either be an entity of undefined.
 


### PR DESCRIPTION
This PR fixes a typo in de doc (README.md)
`usQueryFirst` -> `useQueryFirst`