### PR TITLE
feat: world now can lazy init, no longer cleans itself up

### DIFF
--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -17,10 +17,15 @@ describe('World', () => {
 	});
 
 	it('should optionaly init lazily', () => {
+		const Test = trait({ last: 0, delta: 0 });
+
 		const world = createWorld({ lazy: true });
 		expect(world.isInitialized).toBe(false);
-		world.init();
+
+		world.init(Test);
+
 		expect(world.isInitialized).toBe(true);
+		expect(world.get(Test)).toBeDefined();
 	});
 
 	it('should reset the world', () => {
@@ -63,6 +68,24 @@ describe('World', () => {
 		// Expect this to not throw, since the ChildOf relation will automatically
 		// remove the child node when the parent node is destroyed first
 		expect(() => world.destroy()).not.toThrow();
+	});
+
+	it('should be able to init after destroy', () => {
+		const world = createWorld({ lazy: true });
+		expect(world.entities.length).toBe(0);
+
+		world.init();
+		expect(world.entities.length).toBe(1);
+
+		world.destroy();
+		expect(world.entities.length).toBe(0);
+
+		world.init();
+		expect(world.isInitialized).toBe(true);
+
+		// Can add entities
+		world.spawn();
+		expect(world.entities.length).toBe(2);
 	});
 
 	it('errors if more than 16 worlds are created', () => {


### PR DESCRIPTION
World has a side effect, it registers itself with the universe on init. This is fine in most cases, because dispose is called to clean this up. However, in cases like React a new world is created and discarded in a useMemo leaving side effects without any cleanup. I experimented with fixing this by implementing FinalizationRegistry with Weakrefs, allowing the world to get garbage collected and unbind its link at that point. This worked great, but it had negative performance effects everywhere the world was referenced from the universe (entity methods). This is not worth it. So instead this makes it so you can optionally create a world with a lazy option and then init it manually in an effect. This is the correct, explicit flow.

```js
world = useMemo(() => createWorld({ lazy: true }), []);

useEffect(() => {
  world.init();
  return () => world.destroy();
}, [world]);
```