### PR TITLE
fix: update setChanged logic to correctly populate changedMask

### DIFF
--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -34,9 +34,21 @@ export function setChanged(world: World, entity: Entity, trait: Trait) {
 	// This is used for filling initial values for Changed modifiers.
 	for (const changedMask of ctx.changedMasks.values()) {
 		const eid = getEntityId(entity);
-		if (!changedMask[eid]) changedMask[eid] = [];
-		const traitId = trait[$internal].id;
-		changedMask[eid][traitId] = 1;
+		const data = ctx.traitData.get(trait)!;
+		const { generationId, bitflag } = data;
+
+		// Ensure the generation array exists
+		if (!changedMask[generationId]) {
+			changedMask[generationId] = [];
+		}
+
+		// Ensure the entity mask exists
+		if (!changedMask[generationId][eid]) {
+			changedMask[generationId][eid] = 0;
+		}
+
+		// Set the bit for this trait
+		changedMask[generationId][eid] |= bitflag;
 	}
 
 	// Update queries.

--- a/packages/core/tests/query-modifiers.test.ts
+++ b/packages/core/tests/query-modifiers.test.ts
@@ -498,4 +498,17 @@ describe('Query modifiers', () => {
 		entity.remove(Foo);
 		expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
 	});
+
+	it('should correctly populate Changed query when trait changes happen before query initialization', () => {
+		// Create change modifier and spawn an entity
+		const Changed = createChanged();
+		const entity = world.spawn(Foo, Bar);
+
+		// Mark Bar as changed
+		entity.changed(Bar);
+
+		// Even if the query wasn't executed before,
+		// it should pick up the trait change
+		expect(world.queryFirst(Changed(Bar))).toBe(entity);
+	});
 });

--- a/packages/publish/tests/core/query-modifiers.test.ts
+++ b/packages/publish/tests/core/query-modifiers.test.ts
@@ -498,4 +498,17 @@ describe('Query modifiers', () => {
 		entity.remove(Foo);
 		expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
 	});
+
+	it('should correctly populate Changed query when trait changes happen before query initialization', () => {
+		// Create change modifier and spawn an entity
+		const Changed = createChanged();
+		const entity = world.spawn(Foo, Bar);
+
+		// Mark Bar as changed
+		entity.changed(Bar);
+
+		// Even if the query wasn't executed before,
+		// it should pick up the trait change
+		expect(world.queryFirst(Changed(Bar))).toBe(entity);
+	});
 });


### PR DESCRIPTION
Initial query population logic could previously produce incorrect results due to `setChanged` using `changedMask` in a different way, compared to other places:

- In `Query`, when we work with individual `changedMask` (from `ctx.changedMasks.get(id)!`), we use it as `changedMask[generationId][eid]`
- In `setChanged`, when we iterate over `changedMask` (from `ctx.changedMasks.values()`), we use it as `changedMask[eid][traitId]`

In this PR we ensure `changedMask` usage stays consistent with existing patterns
