### PR TITLE
fix: Tag trait inference

### DIFF
--- a/packages/core/src/trait/trait.ts
+++ b/packages/core/src/trait/trait.ts
@@ -11,6 +11,7 @@ import type {
 	Norm,
 	Schema,
 	Store,
+	TagTrait,
 	Trait,
 	TraitData,
 	TraitType,
@@ -26,6 +27,8 @@ import { validateSchema } from './utils/validate-schema';
 
 let traitId = 0;
 
+function defineTrait(schema?: undefined | Record<string, never>): TagTrait;
+function defineTrait<S extends Schema>(schema: S): Trait<Norm<S>>;
 function defineTrait<S extends Schema>(schema: S = {} as S): Trait<Norm<S>> {
 	const isAoS = typeof schema === 'function';
 	const traitType: TraitType = isAoS ? 'aos' : 'soa';

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -1,6 +1,6 @@
 import { $internal } from '../common';
-import { Entity } from '../entity/types';
-import { Query } from '../query/types';
+import type { Entity } from '../entity/types';
+import type { Query } from '../query/types';
 import type { Relation, RelationTarget } from '../relation/types';
 import type { IsEmpty } from '../utils/types';
 
@@ -10,11 +10,7 @@ export type TraitValue<TSchema extends Schema> = TSchema extends AoSFactory
 	? ReturnType<TSchema>
 	: Partial<TraitInstance<TSchema>>;
 
-export type Trait<
-	TSchema extends Schema = any,
-	TStore = Store<TSchema>,
-	TTag extends boolean = IsEmpty<TSchema>
-> = {
+export type Trait<TSchema extends Schema = any> = {
 	schema: TSchema;
 	[$internal]: {
 		set: (index: number, store: any, value: TraitValue<TSchema>) => void;
@@ -25,20 +21,20 @@ export type Trait<
 			value: TraitValue<TSchema>
 		) => boolean;
 		get: (index: number, store: any) => TraitInstance<TSchema>;
-		stores: TStore[];
+		stores: Store<TSchema>[];
 		id: number;
-		createStore: () => TStore;
+		createStore: () => Store<TSchema>;
 		isPairTrait: boolean;
 		relation: Relation<any> | null;
 		pairTarget: RelationTarget | null;
-		isTag: TTag;
+		isTag: IsEmpty<TSchema>;
 		type: TraitType;
 	};
-} & ((params?: TraitValue<TSchema>) => [Trait<TSchema, TStore, TTag>, TraitValue<TSchema>]);
+} & ((params?: TraitValue<TSchema>) => [Trait<TSchema>, TraitValue<TSchema>]);
 
 export type TraitTuple<T extends Trait = Trait> = [
 	T,
-	T extends Trait<infer S, any>
+	T extends Trait<infer S>
 		? S extends AoSFactory
 			? ReturnType<S>
 			: Partial<TraitInstance<S>>
@@ -47,14 +43,6 @@ export type TraitTuple<T extends Trait = Trait> = [
 
 export type ConfigurableTrait<T extends Trait = Trait> = T | TraitTuple<T>;
 
-type TraitInstanceFromTrait<T extends Trait> = T['schema'] extends AoSFactory
-	? ReturnType<T['schema']>
-	: {
-			[P in keyof T['schema']]: T['schema'][P] extends (...args: any[]) => any
-				? ReturnType<T['schema'][P]>
-				: T['schema'][P];
-	  };
-
 export type SetTraitCallback<T extends Trait> = (
 	prev: TraitInstance<ExtractSchema<T>>
 ) => TraitValue<ExtractSchema<T>>;
@@ -62,11 +50,11 @@ export type SetTraitCallback<T extends Trait> = (
 type TraitInstanceFromSchema<T extends Schema> = T extends AoSFactory
 	? ReturnType<T>
 	: {
-			[P in keyof T]: T[P] extends (...args: any[]) => any ? ReturnType<T[P]> : T[P];
+			[P in keyof T]: T[P] extends (...args: never[]) => unknown ? ReturnType<T[P]> : T[P];
 	  };
 
 export type TraitInstance<T extends Trait | Schema> = T extends Trait
-	? TraitInstanceFromTrait<T>
+	? TraitInstanceFromSchema<T['schema']>
 	: TraitInstanceFromSchema<T>;
 
 export type Schema =
@@ -80,7 +68,7 @@ export type AoSFactory = () => unknown;
 export type Store<T extends Schema = any> = T extends AoSFactory
 	? ReturnType<T>[]
 	: {
-			[P in keyof T]: T[P] extends (...args: any[]) => any ? ReturnType<T[P]>[] : T[P][];
+			[P in keyof T]: T[P] extends (...args: never[]) => unknown ? ReturnType<T[P]>[] : T[P][];
 	  };
 
 // Type Utils
@@ -97,7 +85,7 @@ export type Norm<T extends Schema> = T extends AoSFactory
 			: ReturnType<T>
 	: {
 			[K in keyof T]: T[K] extends object
-				? T[K] extends (...args: any[]) => any
+				? T[K] extends (...args: never[]) => unknown
 					? T[K]
 					: never
 				: T[K] extends boolean
@@ -114,10 +102,10 @@ export type ExtractSchema<T extends Trait | Relation<Trait>> = T extends Relatio
 	: T extends Trait<infer S>
 	? S
 	: never;
-export type ExtractStore<T extends Trait> = T extends Trait<any, infer S> ? S : never;
-export type ExtractIsTag<T extends Trait> = T extends Trait<any, any, infer Tag> ? Tag : false;
+export type ExtractStore<T extends Trait> = T extends { [$internal]: { createStore(): infer Store } } ? Store : never;
+export type ExtractIsTag<T extends Trait> = T extends { [$internal]: { isTag: true } } ? true : false;
 
-export type IsTag<T extends Trait> = T extends Trait<any, any, infer Tag> ? Tag : false;
+export type IsTag<T extends Trait> = ExtractIsTag<T>;
 
 export interface TraitData<T extends Trait = Trait, S extends Schema = ExtractSchema<T>> {
 	generationId: number;

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -32,6 +32,8 @@ export type Trait<TSchema extends Schema = any> = {
 	};
 } & ((params?: TraitValue<TSchema>) => [Trait<TSchema>, TraitValue<TSchema>]);
 
+export type TagTrait = Trait<Record<string, never>>;
+
 export type TraitTuple<T extends Trait = Trait> = [
 	T,
 	T extends Trait<infer S>
@@ -61,7 +63,8 @@ export type Schema =
 	| {
 			[key: string]: number | bigint | string | boolean | null | undefined | (() => unknown);
 	  }
-	| AoSFactory;
+	| AoSFactory
+	| Record<string, never>;
 
 export type AoSFactory = () => unknown;
 
@@ -75,27 +78,29 @@ export type Store<T extends Schema = any> = T extends AoSFactory
 
 // This type utility ensures that explicit values like true, false or "string literal" are
 // normalized to their primitive types. Mostly used for schema types.
-export type Norm<T extends Schema> = T extends AoSFactory
-	? () => ReturnType<T> extends number
-			? number
-			: ReturnType<T> extends boolean
-			? boolean
-			: ReturnType<T> extends string
-			? string
-			: ReturnType<T>
-	: {
-			[K in keyof T]: T[K] extends object
-				? T[K] extends (...args: never[]) => unknown
-					? T[K]
-					: never
-				: T[K] extends boolean
-				? boolean
-				: T[K];
-	  }[keyof T] extends never
-	? never
-	: {
-			[K in keyof T]: T[K] extends boolean ? boolean : T[K];
-	  };
+export type Norm<T extends Schema> = T extends Record<string, never>
+	? T
+	: T extends AoSFactory
+  	? () => ReturnType<T> extends number
+  			? number
+  			: ReturnType<T> extends boolean
+  			? boolean
+  			: ReturnType<T> extends string
+  			? string
+  			: ReturnType<T>
+  	: {
+  			[K in keyof T]: T[K] extends object
+  				? T[K] extends (...args: never[]) => unknown
+  					? T[K]
+  					: never
+  				: T[K] extends boolean
+  				? boolean
+  				: T[K];
+  	  }[keyof T] extends never
+  	? never
+  	: {
+  			[K in keyof T]: T[K] extends boolean ? boolean : T[K];
+  	  };
 
 export type ExtractSchema<T extends Trait | Relation<Trait>> = T extends Relation<infer R>
 	? ExtractSchema<R>


### PR DESCRIPTION
Hey Kris! 👋

I've been getting back into working on [wayfare](https://github.com/iwoplaza/wayfare), and I noticed that tag traits are inferred to be the widest trait type.

```ts
const Position = trait({ position: () => [1, 2, 3] });
//    ^? Trait<() => number[]>

const IsPlayer = trait();
//    ^? Trait
```

I guess the more accurate type would be `Trait<Record<string, never>>`, so I added a function overload to cover that case. I am using a type alias `TagTrait` to look a but better on hover.

Given the opportunity, I also played around with removing the derivative `TStore` and `TTag` generic parameters, since they solely depend on the `TSchema` generic parameter.