### PR TITLE
feat: command buffer

### DIFF
--- a/packages/core/src/query/event-listeners.ts
+++ b/packages/core/src/query/event-listeners.ts
@@ -1,0 +1,39 @@
+import { $internal } from '../common';
+import type { World } from '../world/world';
+import type { StoreUpdateEvent } from '../world/events';
+
+/**
+ * Set up query event listeners for store update events.
+ * This replaces the direct query updates that used to happen in trait operations.
+ */
+export function setupQueryEventListeners(world: World): void {
+	const ctx = world[$internal];
+
+	// Listen for store update events and update queries accordingly
+	ctx.storeEventEmitter.on((event: StoreUpdateEvent) => {
+		handleStoreUpdateEvent(world, event);
+	});
+}
+
+/**
+ * Handle a store update event by updating relevant queries
+ */
+function handleStoreUpdateEvent(world: World, event: StoreUpdateEvent): void {
+	const { type, entity, traitData } = event;
+	const { queries } = traitData;
+
+	// Update all queries that care about this trait
+	for (const query of queries) {
+		// Remove this entity from toRemove if it exists in this query.
+		query.toRemove.remove(entity);
+
+		// Check if the entity matches the query after the store update.
+		const match = query.check(world, entity, { type, traitData });
+
+		if (match) {
+			query.add(entity);
+		} else {
+			query.remove(world, entity);
+		}
+	}
+}

--- a/packages/core/src/trait/commands.ts
+++ b/packages/core/src/trait/commands.ts
@@ -1,0 +1,145 @@
+import { $internal } from '../common';
+import type { Entity } from '../entity/types';
+import { getEntityId } from '../entity/utils/pack-entity';
+import { getRelationTargets, Pair, Wildcard } from '../relation/relation';
+import type { Command } from '../utils/command-buffer';
+import type { World } from '../world/world';
+import { addTrait, hasTrait, registerTrait, removeTrait, setTrait } from './trait';
+import type { Trait } from './types';
+
+const COMMAND_TYPES = {
+	ADD: 'add',
+	REMOVE: 'remove',
+} as const;
+
+type CommandType = (typeof COMMAND_TYPES)[keyof typeof COMMAND_TYPES];
+
+type CommandArgs = {
+	add: {
+		world: World;
+		entity: Entity;
+		trait: Trait;
+		params?: Record<string, any>;
+	};
+	remove: {
+		world: World;
+		entity: Entity;
+		trait: Trait;
+	};
+};
+
+export interface GenericCommand<T extends CommandType = CommandType> extends Command {
+	type: T;
+	args: CommandArgs[T];
+}
+
+// Overloaded function signatures for type safety
+export function command(type: 'add', args: CommandArgs['add']): GenericCommand<'add'>;
+export function command(type: 'remove', args: CommandArgs['remove']): GenericCommand<'remove'>;
+export function command<T extends CommandType>(type: T, args: CommandArgs[T]): GenericCommand<T> {
+	return {
+		type,
+		args,
+		execute() {
+			switch (type) {
+				case 'add':
+					const { world, entity, trait, params } = args as CommandArgs['add'];
+					commitAddTrait(world, entity, trait, params);
+					break;
+				case 'remove':
+					throw new Error('Remove command not yet implemented');
+				default:
+					throw new Error(`Unknown command type: ${type}`);
+			}
+		},
+	};
+}
+
+/**
+ * Commits a single trait addition. This contains the core logic
+ * that was previously in addTrait.
+ */
+function commitAddTrait(world: World, entity: Entity, trait: Trait, params?: Record<string, any>) {
+	const ctx = world[$internal];
+
+	// Exit early if the entity already has the trait.
+	if (hasTrait(world, entity, trait)) return;
+
+	const traitCtx = trait[$internal];
+
+	// Register the trait if it's not already registered.
+	if (!ctx.traitData.has(trait)) registerTrait(world, trait);
+
+	const data = ctx.traitData.get(trait)!;
+	const { generationId, bitflag, queries } = data;
+
+	// Add bitflag to entity bitmask.
+	const eid = getEntityId(entity);
+	ctx.entityMasks[generationId][eid] |= bitflag;
+
+	// Set the entity as dirty.
+	for (const dirtyMask of ctx.dirtyMasks.values()) {
+		if (!dirtyMask[generationId]) dirtyMask[generationId] = [];
+		dirtyMask[generationId][eid] |= bitflag;
+	}
+
+	// Update queries.
+	for (const query of queries) {
+		// Remove this entity from toRemove if it exists in this query.
+		query.toRemove.remove(entity);
+
+		// Check if the entity matches the query.
+		const match = query.check(world, entity, { type: 'add', traitData: data });
+
+		if (match) query.add(entity);
+		else query.remove(world, entity);
+	}
+
+	// Add trait to entity internally.
+	ctx.entityTraits.get(entity)!.add(trait);
+
+	const relation = traitCtx.relation;
+	const target = traitCtx.pairTarget;
+
+	// Add relation target entity.
+	if (traitCtx.isPairTrait && relation !== null && target !== null) {
+		// Mark entity as a relation target.
+		ctx.relationTargetEntities.add(target);
+
+		// Add wildcard relation traits.
+		addTrait(world, entity, Pair(Wildcard, target));
+		addTrait(world, entity, Pair(relation, Wildcard));
+
+		// If it's an exclusive relation, remove the old target.
+		if (relation[$internal].exclusive === true && target !== Wildcard) {
+			const oldTarget = getRelationTargets(world, relation, entity)[0];
+
+			if (oldTarget !== null && oldTarget !== undefined && oldTarget !== target) {
+				removeTrait(world, entity, relation(oldTarget));
+			}
+		}
+	}
+
+	if (traitCtx.type === 'soa') {
+		// Set default values or override with provided params.
+		const defaults: Record<string, any> = {};
+		// Execute any functions in the schema for default values.
+		for (const key in data.schema) {
+			if (typeof data.schema[key] === 'function') {
+				defaults[key] = data.schema[key]();
+			} else {
+				defaults[key] = data.schema[key];
+			}
+		}
+
+		setTrait(world, entity, trait, { ...defaults, ...params }, false);
+	} else {
+		const state = params ?? data.schema();
+		setTrait(world, entity, trait, state, false);
+	}
+
+	// Call add subscriptions.
+	for (const sub of data.addSubscriptions) {
+		sub(entity);
+	}
+}

--- a/packages/core/src/utils/command-buffer.ts
+++ b/packages/core/src/utils/command-buffer.ts
@@ -1,0 +1,32 @@
+export interface Command {
+	execute(): void;
+}
+
+export class CommandBuffer {
+	private commands: Command[] = [];
+
+	enqueue(command: Command): void {
+		this.commands.push(command);
+	}
+
+	flush(): void {
+		const commandsToExecute = this.commands.slice();
+		this.commands.length = 0;
+
+		for (const command of commandsToExecute) {
+			command.execute();
+		}
+	}
+
+	get length(): number {
+		return this.commands.length;
+	}
+
+	get isEmpty(): boolean {
+		return this.commands.length === 0;
+	}
+
+	clear(): void {
+		this.commands.length = 0;
+	}
+}

--- a/packages/core/src/utils/event-emitter.ts
+++ b/packages/core/src/utils/event-emitter.ts
@@ -1,0 +1,55 @@
+export type EventListener<T = any> = (event: T) => void;
+
+/**
+ * Generic event emitter that can handle any event type with proper typing
+ */
+export class EventEmitter<T = any> {
+	private listeners: EventListener<T>[] = [];
+
+	/**
+	 * Subscribe to events
+	 */
+	on(listener: EventListener<T>): void {
+		this.listeners.push(listener);
+	}
+
+	/**
+	 * Unsubscribe from events
+	 */
+	off(listener: EventListener<T>): void {
+		const index = this.listeners.indexOf(listener);
+		if (index !== -1) {
+			this.listeners.splice(index, 1);
+		}
+	}
+
+	/**
+	 * Emit an event to all listeners
+	 */
+	emit(event: T): void {
+		for (const listener of this.listeners) {
+			listener(event);
+		}
+	}
+
+	/**
+	 * Clear all listeners
+	 */
+	clear(): void {
+		this.listeners.length = 0;
+	}
+
+	/**
+	 * Get the number of listeners
+	 */
+	get listenerCount(): number {
+		return this.listeners.length;
+	}
+
+	/**
+	 * Check if there are any listeners
+	 */
+	get hasListeners(): boolean {
+		return this.listeners.length > 0;
+	}
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,2 +1,3 @@
+export { CommandBuffer, type Command } from './command-buffer';
 export { Deque } from './deque';
 export { SparseSet } from './sparse-set';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { CommandBuffer, type Command } from './command-buffer';
 export { Deque } from './deque';
+export { EventEmitter, type EventListener } from './event-emitter';
 export { SparseSet } from './sparse-set';

--- a/packages/core/src/world/events.ts
+++ b/packages/core/src/world/events.ts
@@ -1,0 +1,18 @@
+import type { Entity } from '../entity/types';
+import type { Trait, TraitData } from '../trait/types';
+import { EventEmitter } from '../utils/event-emitter';
+
+// Store update event types
+export type StoreUpdateEventType = 'add' | 'remove' | 'change';
+
+export interface StoreUpdateEvent {
+	type: StoreUpdateEventType;
+	entity: Entity;
+	trait: Trait;
+	traitData: TraitData;
+}
+
+/**
+ * Typed event emitter for store update events
+ */
+export class StoreEventEmitter extends EventEmitter<StoreUpdateEvent> {}

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -25,6 +25,7 @@ import type {
 	TraitValue,
 } from '../trait/types';
 import { universe } from '../universe/universe';
+import { CommandBuffer } from '../utils/command-buffer';
 import { allocateWorldId, releaseWorldId } from './utils/world-index';
 
 type Options = {
@@ -52,6 +53,7 @@ export class World {
 		worldEntity: null! as Entity,
 		trackedTraits: new Set<Trait>(),
 		resetSubscriptions: new Set<(world: World) => void>(),
+		commandBuffer: new CommandBuffer(),
 	};
 
 	get id() {
@@ -176,6 +178,7 @@ export class World {
 		ctx.dirtyMasks.clear();
 		ctx.changedMasks.clear();
 		ctx.trackedTraits.clear();
+		ctx.commandBuffer.clear();
 
 		// Create new world entity.
 		ctx.worldEntity = createEntity(this, IsExcluded);

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -26,7 +26,9 @@ import type {
 } from '../trait/types';
 import { universe } from '../universe/universe';
 import { CommandBuffer } from '../utils/command-buffer';
+import { StoreEventEmitter } from './events';
 import { allocateWorldId, releaseWorldId } from './utils/world-index';
+import { setupQueryEventListeners } from '../query/event-listeners';
 
 type Options = {
 	traits?: ConfigurableTrait[];
@@ -54,6 +56,7 @@ export class World {
 		trackedTraits: new Set<Trait>(),
 		resetSubscriptions: new Set<(world: World) => void>(),
 		commandBuffer: new CommandBuffer(),
+		storeEventEmitter: new StoreEventEmitter(),
 	};
 
 	get id() {
@@ -104,6 +107,9 @@ export class World {
 
 		// Create world entity.
 		ctx.worldEntity = createEntity(this, IsExcluded, ...traits);
+
+		// Set up query event listeners for store updates
+		setupQueryEventListeners(this);
 	}
 
 	spawn(...traits: ConfigurableTrait[]): Entity {
@@ -179,6 +185,7 @@ export class World {
 		ctx.changedMasks.clear();
 		ctx.trackedTraits.clear();
 		ctx.commandBuffer.clear();
+		ctx.storeEventEmitter.clear();
 
 		// Create new world entity.
 		ctx.worldEntity = createEntity(this, IsExcluded);

--- a/packages/core/tests/utils/command-buffer.test.ts
+++ b/packages/core/tests/utils/command-buffer.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandBuffer, type Command } from '../../src/utils/command-buffer';
+
+describe('CommandBuffer', () => {
+	let buffer: CommandBuffer;
+
+	beforeEach(() => {
+		buffer = new CommandBuffer();
+	});
+
+	it('should enqueue and execute commands in order', () => {
+		const executionOrder: number[] = [];
+		const command1: Command = { execute: () => executionOrder.push(1) };
+		const command2: Command = { execute: () => executionOrder.push(2) };
+
+		buffer.enqueue(command1);
+		buffer.enqueue(command2);
+		expect(buffer.length).toBe(2);
+
+		buffer.flush();
+
+		expect(executionOrder).toEqual([1, 2]);
+		expect(buffer.isEmpty).toBe(true);
+	});
+
+	it('should clear commands without executing them', () => {
+		const command = { execute: vi.fn() };
+
+		buffer.enqueue(command);
+		buffer.clear();
+
+		expect(buffer.isEmpty).toBe(true);
+		expect(command.execute).not.toHaveBeenCalled();
+	});
+
+	it('should handle empty buffer', () => {
+		expect(buffer.isEmpty).toBe(true);
+		expect(buffer.length).toBe(0);
+		expect(() => buffer.flush()).not.toThrow();
+	});
+});

--- a/packages/core/tests/utils/event-emitter.test.ts
+++ b/packages/core/tests/utils/event-emitter.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from '../../src/utils/event-emitter';
+
+interface TestEvent {
+	type: string;
+	data: number;
+}
+
+describe('EventEmitter', () => {
+	let emitter: EventEmitter<TestEvent>;
+
+	beforeEach(() => {
+		emitter = new EventEmitter<TestEvent>();
+	});
+
+	it('should emit events to listeners', () => {
+		const listener1 = vi.fn();
+		const listener2 = vi.fn();
+		const event: TestEvent = { type: 'test', data: 42 };
+
+		emitter.on(listener1);
+		emitter.on(listener2);
+		emitter.emit(event);
+
+		expect(listener1).toHaveBeenCalledWith(event);
+		expect(listener2).toHaveBeenCalledWith(event);
+		expect(emitter.listenerCount).toBe(2);
+	});
+
+	it('should remove listeners', () => {
+		const listener = vi.fn();
+		const event: TestEvent = { type: 'test', data: 42 };
+
+		emitter.on(listener);
+		emitter.off(listener);
+		emitter.emit(event);
+
+		expect(listener).not.toHaveBeenCalled();
+		expect(emitter.listenerCount).toBe(0);
+	});
+
+	it('should clear all listeners', () => {
+		const listener1 = vi.fn();
+		const listener2 = vi.fn();
+
+		emitter.on(listener1);
+		emitter.on(listener2);
+		emitter.clear();
+
+		expect(emitter.listenerCount).toBe(0);
+		expect(emitter.hasListeners).toBe(false);
+	});
+
+	it('should handle empty emitter', () => {
+		const event: TestEvent = { type: 'test', data: 42 };
+
+		expect(() => emitter.emit(event)).not.toThrow();
+		expect(emitter.hasListeners).toBe(false);
+	});
+});


### PR DESCRIPTION
In order to fully decouple the different internal domains, I wanted to explore implementing command buffers. But also this lays the groundwork for MT since workers can enqueue commands and a scheduler can execute all commands in batch, in the order they were enqueued.

Here are the initial notes:

> - Parse arguments (single trait or multiple, etc).
> - Enqueue an "Add" command for each trait.
> - Flush the command buffer immediately as it is synchronous.
> - A separate commit routine runs when the command buffer is flushed and runs commitAdd.
> - This collects all the add commands together and batch updates the stores, reducing the need to loop. (Different store strategies can be added here, for example archetypes.)
> - When stores are updated, a store update event is emitted (maybe different depending on the update?).
> - A query routine listens for this event and updates the query's cache.
> - An Added event is emitted for userland listeners.
> 
> Add command gets enqueued -> Add command gets committed -> world entity-trait tables update -> table update events emit -> queries listen to this and update synchronously -> userland add events emit