### PR TITLE
chore: rename TraitInstance to TraitRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,8 +503,8 @@ world.remove(Time)
 // Return boolean
 const result = world.has(Time)
 
-// Gets a snapshot instance of the trait
-// Return TraitInstance
+// Returns the trait record for the world
+// Return TraitRecord
 const time = world.get(Time)
 
 // Sets the trait and triggers a change event
@@ -559,8 +559,8 @@ entity.remove(Position)
 // Return boolean
 const result = entity.has(Position)
 
-// Gets a snapshot instance of the trait
-// Return TraitInstance
+// Gets the trait record for an entity
+// Return TraitRecord
 const position = entity.get(Position)
 
 // Sets the trait and triggers a change event
@@ -678,38 +678,63 @@ const store = [
 const Mesh = trait(() => new THREE.Mesh())
 ```
 
+#### Trait record
+
+The state of a given entity-trait pair is called a trait record and is like the row of a table in a database. When the trait store is SoA the record returned is a snapshot of the state while when it is AoS the record is a ref to the object inserted there.
+
+```js
+// SoA store
+const Position = trait({ x: 0, y: 0, z: 0 })
+entity.add(Position)
+// Returns a snapshot of the arrays
+const position = entity.get(Position)
+// position !== position2
+const position2 = entity.get(Position)
+
+// AoS store
+const Velocity = trait(() => ({ x: 0, y: 0, z: 0 }))
+entity.add(Velocity)
+// Returns a ref to the object inserted
+const velocity = entity.get(Velocity)
+// velocity === velocity2
+const velocity2 = entity.get(Velocity)
+```
+
+Use `TraitRecord` to type this state.
+
+```ts
+const PositionRecord = TraitRecord<typeof Position>
+```
+
 #### Typing traits
 
 Traits can have a schema type passed into its generic. This can be useful if the inferred type is not good enough.
 
-```js
+```ts
 type AttackerSchema = {
-  continueCombo: boolean | null,
-  currentStageIndex: number | null,
-  stages: Array<AttackStage> | null,
-  startedAt: number | null,
+  continueCombo: boolean | null
+  currentStageIndex: number | null
+  stages: Array<AttackStage> | null
+  startedAt: number | null
 }
 
-const Attacker =
-  trait <
-  AttackerSchema >
-  {
-    continueCombo: null,
-    currentStageIndex: null,
-    stages: null,
-    startedAt: null,
-  }
+const Attacker = trait<AttackerSchema>({
+  continueCombo: null,
+  currentStageIndex: null,
+  stages: null,
+  startedAt: null,
+})
 ```
 
 However, this will not work with interfaces without a workaround due to intended behavior in TypeScript: https://github.com/microsoft/TypeScript/issues/15300
 Interfaces can be used with `Pick` to convert the key signatures into something our type code can understand.
 
-```js
+```ts
 interface AttackerSchema {
-  continueCombo: boolean | null,
-  currentStageIndex: number | null,
-  stages: Array<AttackStage> | null,
-  startedAt: number | null,
+  continueCombo: boolean | null
+  currentStageIndex: number | null
+  stages: Array<AttackStage> | null
+  startedAt: number | null
 }
 
 // Pick is required to not get type errors

--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -4,7 +4,7 @@ import type {
 	ExtractSchema,
 	SetTraitCallback,
 	Trait,
-	TraitInstance,
+	TraitRecord,
 	TraitValue,
 } from '../trait/types';
 
@@ -19,7 +19,7 @@ export type Entity = number & {
 		value: TraitValue<ExtractSchema<T>> | SetTraitCallback<T>,
 		flagChanged?: boolean
 	) => void;
-	get: <T extends Trait | Relation<Trait>>(trait: T) => TraitInstance<ExtractSchema<T>> | undefined;
+	get: <T extends Trait | Relation<Trait>>(trait: T) => TraitRecord<ExtractSchema<T>> | undefined;
 	targetFor: <T extends Trait>(relation: Relation<T>) => Entity | undefined;
 	targetsFor: <T extends Trait>(relation: Relation<T>) => Entity[];
 	id: () => number;

--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -5,7 +5,7 @@ import type {
 	ExtractStore,
 	IsTag,
 	Trait,
-	TraitInstance,
+	TraitRecord,
 	TraitData,
 	Store,
 } from '../trait/types';
@@ -56,7 +56,7 @@ export type InstancesFromParameters<T extends QueryParameter[]> = T extends [
 				? IsTag<First> extends false
 					? ExtractSchema<First> extends AoSFactory
 						? [ReturnType<ExtractSchema<First>>]
-						: [TraitInstance<First>]
+						: [TraitRecord<First>]
 					: []
 				: First extends ModifierData
 				? IsNotModifier<First> extends true

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -21,7 +21,7 @@ import type {
 	SetTraitCallback,
 	Trait,
 	TraitData,
-	TraitInstance,
+	TraitRecord,
 	TraitValue,
 } from '../trait/types';
 import { universe } from '../universe/universe';
@@ -124,7 +124,7 @@ export class World {
 		removeTrait(this, this[$internal].worldEntity, ...traits);
 	}
 
-	get<T extends Trait>(trait: T): TraitInstance<ExtractSchema<T>> | undefined {
+	get<T extends Trait>(trait: T): TraitRecord<ExtractSchema<T>> | undefined {
 		return getTrait(this, this[$internal].worldEntity, trait);
 	}
 

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createWorld, relation, type TraitInstance, trait, universe } from '../src';
+import { createWorld, relation, type TraitRecord, trait, universe } from '../src';
 
 describe('World', () => {
 	beforeEach(() => {
@@ -137,7 +137,7 @@ describe('World', () => {
 		const TimeOfDay = trait({ hour: 0 });
 		const world = createWorld(TimeOfDay);
 
-		let timeOfDay: TraitInstance<typeof TimeOfDay> | undefined;
+		let timeOfDay: TraitRecord<typeof TimeOfDay> | undefined;
 		world.onChange(TimeOfDay, (e) => {
 			timeOfDay = e.get(TimeOfDay);
 		});

--- a/packages/react/src/hooks/use-trait-effect.ts
+++ b/packages/react/src/hooks/use-trait-effect.ts
@@ -1,4 +1,4 @@
-import { $internal, type Entity, type Trait, type TraitInstance, type World } from '@koota/core';
+import { $internal, type Entity, type Trait, type TraitRecord, type World } from '@koota/core';
 import { useEffect, useMemo, useRef } from 'react';
 import { isWorld } from '../utils/is-world';
 import { useWorld } from '../world/use-world';
@@ -6,7 +6,7 @@ import { useWorld } from '../world/use-world';
 export function useTraitEffect<T extends Trait>(
 	target: Entity | World,
 	trait: T,
-	callback: (value: TraitInstance<T> | undefined) => void
+	callback: (value: TraitRecord<T> | undefined) => void
 ) {
 	const contextWorld = useWorld();
 	const world = useMemo(() => (isWorld(target) ? target : contextWorld), [target, contextWorld]);

--- a/packages/react/src/hooks/use-trait.ts
+++ b/packages/react/src/hooks/use-trait.ts
@@ -1,4 +1,4 @@
-import { $internal, type Entity, type Trait, type TraitInstance, type World } from '@koota/core';
+import { $internal, type Entity, type Trait, type TraitRecord, type World } from '@koota/core';
 import { useEffect, useMemo, useState } from 'react';
 import { isWorld } from '../utils/is-world';
 import { useWorld } from '../world/use-world';
@@ -6,7 +6,7 @@ import { useWorld } from '../world/use-world';
 export function useTrait<T extends Trait>(
 	target: Entity | World | undefined | null,
 	trait: T
-): TraitInstance<T> | undefined {
+): TraitRecord<T> | undefined {
 	// Get the world from context -- it may be used.
 	// Note: With React 19 we can get it with use conditionally.
 	const contextWorld = useWorld();
@@ -19,7 +19,7 @@ export function useTrait<T extends Trait>(
 	);
 
 	// Initialize the state with the current value of the trait.
-	const [value, setValue] = useState<TraitInstance<T> | undefined>(() => {
+	const [value, setValue] = useState<TraitRecord<T> | undefined>(() => {
 		return memo?.entity.has(trait) ? memo?.entity.get(trait) : undefined;
 	});
 
@@ -39,7 +39,7 @@ function createSubscriptions<T extends Trait>(target: Entity | World, trait: T, 
 
 	return {
 		entity,
-		subscribe: (setValue: (value: TraitInstance<T> | undefined) => void) => {
+		subscribe: (setValue: (value: TraitRecord<T> | undefined) => void) => {
 			const onChangeUnsub = world.onChange(trait, (e) => {
 				if (e === entity) setValue(e.get(trait));
 			});

--- a/packages/react/tests/trait.test.tsx
+++ b/packages/react/tests/trait.test.tsx
@@ -1,11 +1,4 @@
-import {
-	createWorld,
-	type Entity,
-	type TraitInstance,
-	trait,
-	universe,
-	type World,
-} from '@koota/core';
+import { createWorld, trait, universe, type Entity, type TraitRecord, type World } from '@koota/core';
 import { render } from '@testing-library/react';
 import { act, StrictMode, useEffect, useState } from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -29,7 +22,7 @@ describe('useTrait', () => {
 
 	it('reactively returns the trait value for an entity', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
 			position = useTrait(entity, Position);
@@ -57,7 +50,7 @@ describe('useTrait', () => {
 
 	it('reactively works with an entity at effect time', async () => {
 		let entity: Entity | undefined;
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
 			const [, set] = useState(0);
@@ -94,7 +87,7 @@ describe('useTrait', () => {
 	it('works with a world', async () => {
 		const TimeOfDay = trait({ hour: 0 });
 		world.add(TimeOfDay);
-		let timeOfDay: TraitInstance<typeof TimeOfDay> | undefined;
+		let timeOfDay: TraitRecord<typeof TimeOfDay> | undefined;
 
 		function Test() {
 			timeOfDay = useTrait(world, TimeOfDay);
@@ -121,7 +114,7 @@ describe('useTrait', () => {
 	});
 
 	it('returns undefined when the target is undefined', async () => {
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 		let entity: Entity | undefined;
 
 		function Test() {
@@ -155,7 +148,7 @@ describe('useTrait', () => {
 
 	it('reactively updates when the world is reset', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
 			position = useTrait(entity, Position);
@@ -192,10 +185,10 @@ describe('useTraitEffect', () => {
 
 	it('reactively calls callback when trait value changes', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
-			useTraitEffect(entity, Position, (value: TraitInstance<typeof Position> | undefined) => {
+			useTraitEffect(entity, Position, (value: TraitRecord<typeof Position> | undefined) => {
 				position = value;
 			});
 			return null;
@@ -222,10 +215,10 @@ describe('useTraitEffect', () => {
 
 	it('calls callback with undefined when trait is removed', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
-			useTraitEffect(entity, Position, (value: TraitInstance<typeof Position> | undefined) => {
+			useTraitEffect(entity, Position, (value: TraitRecord<typeof Position> | undefined) => {
 				position = value;
 			});
 			return null;
@@ -253,10 +246,10 @@ describe('useTraitEffect', () => {
 	it('works with a world trait', async () => {
 		const TimeOfDay = trait({ hour: 0 });
 		world.add(TimeOfDay);
-		let timeOfDay: TraitInstance<typeof TimeOfDay> | undefined;
+		let timeOfDay: TraitRecord<typeof TimeOfDay> | undefined;
 
 		function Test() {
-			useTraitEffect(world, TimeOfDay, (value: TraitInstance<typeof TimeOfDay> | undefined) => {
+			useTraitEffect(world, TimeOfDay, (value: TraitRecord<typeof TimeOfDay> | undefined) => {
 				timeOfDay = value;
 			});
 			return null;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,15 +10,16 @@ catalog:
   '@types/react': ^19.1.8
   '@types/react-dom': ^19.1.6
   '@types/three': ^0.177.0
+  directed: ^0.1.6
   esbuild-plugin-inline-functions: ^0.2.0
   react: ^19.1.1
   react-dom: ^19.1.1
   three: ^0.177.0
-  directed: ^0.1.6
-  vitest: ^3.2.4
   vite: ^6.3.5
+  vitest: ^3.2.4
 
 manage-package-manager-versions: true
 
 onlyBuiltDependencies:
+  - '@swc/core'
   - esbuild


### PR DESCRIPTION
`TraintInstance` isn't really a good term to use. Instance of overloaded and usually refers to a reference while what is returned from `entity.get(Trait)` is a snapshot in the case of an SoA store and ref in the case of an AoS store. More accurate is record since we are turning what is in the virtual database row. 

Addresses: https://github.com/pmndrs/koota/issues/156