### PR TITLE
🐛 core: trait add and remove would early exit with variadic args

### DIFF
--- a/packages/core/src/trait/trait.ts
+++ b/packages/core/src/trait/trait.ts
@@ -103,7 +103,7 @@ export function addTrait(world: World, entity: Entity, ...traits: ConfigurableTr
 		}
 
 		// Exit early if the entity already has the trait.
-		if (hasTrait(world, entity, trait)) return;
+		if (hasTrait(world, entity, trait)) continue;
 
 		const traitCtx = trait[$internal];
 
@@ -193,7 +193,7 @@ export function removeTrait(world: World, entity: Entity, ...traits: Trait[]) {
 		const traitCtx = trait[$internal];
 
 		// Exit early if the entity doesn't have the trait.
-		if (!hasTrait(world, entity, trait)) return;
+		if (!hasTrait(world, entity, trait)) continue;
 
 		const data = ctx.traitData.get(trait)!;
 		const { generationId, bitflag, queries } = data;

--- a/packages/core/tests/trait.test.ts
+++ b/packages/core/tests/trait.test.ts
@@ -6,6 +6,7 @@ class TestClass {
 }
 
 const Position = trait({ x: 0, y: 0 });
+
 const Test = trait({
 	current: 1,
 	test: 'hello',
@@ -14,6 +15,8 @@ const Test = trait({
 	class: () => new TestClass(),
 	bigInt: 1n,
 });
+
+const Tag = trait();
 
 describe('Trait', () => {
 	const world = createWorld();
@@ -51,10 +54,20 @@ describe('Trait', () => {
 		// Add multiple traits at once.
 		entity.add(Position, Test);
 		expect(entity.has(Position)).toBe(true);
+		expect(entity.has(Test)).toBe(true);
 
 		// Remove multiple traits at once.
 		entity.remove(Position, Test);
 		expect(entity.has(Position)).toBe(false);
+		expect(entity.has(Test)).toBe(false);
+
+		// Can still remove multiple traits when one is missing.
+		entity.add(Position, Test);
+		entity.remove(Tag, Position, Test);
+
+		expect(entity.has(Position)).toBe(false);
+		expect(entity.has(Test)).toBe(false);
+		expect(entity.has(Tag)).toBe(false);
 	});
 
 	it('should create SoA stores when registered by adding', () => {

--- a/packages/publish/tests/core/trait.test.ts
+++ b/packages/publish/tests/core/trait.test.ts
@@ -6,6 +6,7 @@ class TestClass {
 }
 
 const Position = trait({ x: 0, y: 0 });
+
 const Test = trait({
 	current: 1,
 	test: 'hello',
@@ -14,6 +15,8 @@ const Test = trait({
 	class: () => new TestClass(),
 	bigInt: 1n,
 });
+
+const Tag = trait();
 
 describe('Trait', () => {
 	const world = createWorld();
@@ -51,10 +54,20 @@ describe('Trait', () => {
 		// Add multiple traits at once.
 		entity.add(Position, Test);
 		expect(entity.has(Position)).toBe(true);
+		expect(entity.has(Test)).toBe(true);
 
 		// Remove multiple traits at once.
 		entity.remove(Position, Test);
 		expect(entity.has(Position)).toBe(false);
+		expect(entity.has(Test)).toBe(false);
+
+		// Can still remove multiple traits when one is missing.
+		entity.add(Position, Test);
+		entity.remove(Tag, Position, Test);
+
+		expect(entity.has(Position)).toBe(false);
+		expect(entity.has(Test)).toBe(false);
+		expect(entity.has(Tag)).toBe(false);
 	});
 
 	it('should create SoA stores when registered by adding', () => {

--- a/packages/publish/tests/core/world.test.ts
+++ b/packages/publish/tests/core/world.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createWorld, relation, type TraitInstance, trait, universe } from '../../dist';
+import { createWorld, relation, type TraitRecord, trait, universe } from '../../dist';
 
 describe('World', () => {
 	beforeEach(() => {
@@ -137,7 +137,7 @@ describe('World', () => {
 		const TimeOfDay = trait({ hour: 0 });
 		const world = createWorld(TimeOfDay);
 
-		let timeOfDay: TraitInstance<typeof TimeOfDay> | undefined;
+		let timeOfDay: TraitRecord<typeof TimeOfDay> | undefined;
 		world.onChange(TimeOfDay, (e) => {
 			timeOfDay = e.get(TimeOfDay);
 		});

--- a/packages/publish/tests/react/trait.test.tsx
+++ b/packages/publish/tests/react/trait.test.tsx
@@ -1,11 +1,4 @@
-import {
-	createWorld,
-	type Entity,
-	type TraitInstance,
-	trait,
-	universe,
-	type World,
-} from '../../dist';
+import { createWorld, trait, universe, type Entity, type TraitRecord, type World } from '../../dist';
 import { render } from '@testing-library/react';
 import { act, StrictMode, useEffect, useState } from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -29,7 +22,7 @@ describe('useTrait', () => {
 
 	it('reactively returns the trait value for an entity', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
 			position = useTrait(entity, Position);
@@ -57,7 +50,7 @@ describe('useTrait', () => {
 
 	it('reactively works with an entity at effect time', async () => {
 		let entity: Entity | undefined;
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
 			const [, set] = useState(0);
@@ -94,7 +87,7 @@ describe('useTrait', () => {
 	it('works with a world', async () => {
 		const TimeOfDay = trait({ hour: 0 });
 		world.add(TimeOfDay);
-		let timeOfDay: TraitInstance<typeof TimeOfDay> | undefined;
+		let timeOfDay: TraitRecord<typeof TimeOfDay> | undefined;
 
 		function Test() {
 			timeOfDay = useTrait(world, TimeOfDay);
@@ -121,7 +114,7 @@ describe('useTrait', () => {
 	});
 
 	it('returns undefined when the target is undefined', async () => {
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 		let entity: Entity | undefined;
 
 		function Test() {
@@ -155,7 +148,7 @@ describe('useTrait', () => {
 
 	it('reactively updates when the world is reset', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
 			position = useTrait(entity, Position);
@@ -192,10 +185,10 @@ describe('useTraitEffect', () => {
 
 	it('reactively calls callback when trait value changes', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
-			useTraitEffect(entity, Position, (value: TraitInstance<typeof Position> | undefined) => {
+			useTraitEffect(entity, Position, (value: TraitRecord<typeof Position> | undefined) => {
 				position = value;
 			});
 			return null;
@@ -222,10 +215,10 @@ describe('useTraitEffect', () => {
 
 	it('calls callback with undefined when trait is removed', async () => {
 		const entity = world.spawn(Position);
-		let position: TraitInstance<typeof Position> | undefined;
+		let position: TraitRecord<typeof Position> | undefined;
 
 		function Test() {
-			useTraitEffect(entity, Position, (value: TraitInstance<typeof Position> | undefined) => {
+			useTraitEffect(entity, Position, (value: TraitRecord<typeof Position> | undefined) => {
 				position = value;
 			});
 			return null;
@@ -253,10 +246,10 @@ describe('useTraitEffect', () => {
 	it('works with a world trait', async () => {
 		const TimeOfDay = trait({ hour: 0 });
 		world.add(TimeOfDay);
-		let timeOfDay: TraitInstance<typeof TimeOfDay> | undefined;
+		let timeOfDay: TraitRecord<typeof TimeOfDay> | undefined;
 
 		function Test() {
-			useTraitEffect(world, TimeOfDay, (value: TraitInstance<typeof TimeOfDay> | undefined) => {
+			useTraitEffect(world, TimeOfDay, (value: TraitRecord<typeof TimeOfDay> | undefined) => {
 				timeOfDay = value;
 			});
 			return null;


### PR DESCRIPTION
If multiple traits were passed into `add` and one was already on the entity then there would be an early exit and the rest would not be added. Same for `remove` and if one trait was not on the entity, there would be an early exit.