### PR TITLE
Remove `world` arg from destroyAllShips function in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ import { useActions } from 'koota/react'
 
 const actions = createActions((world) => ({
   spawnShip: (position) => world.spawn(Position(position), Velocity),
-  destroyAllShips: (world) => {
+  destroyAllShips: () => {
     world.query(Position, Velocity).forEach((entity) => {
       entity.destroy()
     })


### PR DESCRIPTION
Probably a typo since it is not specified at the call point and is supplied by the outer scope already.