### PR TITLE
fix: function inlining is enabled again

### DIFF
--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -100,7 +100,7 @@ import { useActions } from 'koota/react'
 
 const actions = createActions((world) => ({
   spawnShip: (position) => world.spawn(Position(position), Velocity),
-  destroyAllShips: (world) => {
+  destroyAllShips: () => {
     world.query(Position, Velocity).forEach((entity) => {
       entity.destroy()
     })
@@ -117,7 +117,7 @@ function DoomButton() {
     spawnShip({ x: 1, y: 1 })
 
     // Destroy all ships during cleanup
-    return () => drestroyAllShips()
+    return () => destroyAllShips()
   }, [])
 
   // And destroy all ships on click!

--- a/packages/publish/tsup.config.ts
+++ b/packages/publish/tsup.config.ts
@@ -23,9 +23,5 @@ export default defineConfig({
 		resolve: true,
 	},
 	clean: true,
-	esbuildPlugins: [
-		inlineFunctions({
-			include: ['src/**/*.{js,ts,jsx,tsx}'],
-		}),
-	],
+	esbuildPlugins: [inlineFunctions({ include: ['src/**/*.{js,ts,jsx,tsx}'] })],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^0.181.2
       version: 0.181.2
     unplugin-inline-functions:
-      specifier: ^0.3.0
-      version: 0.3.0
+      specifier: ^0.3.3
+      version: 0.3.3
     vite:
       specifier: ^7.2.4
       version: 7.2.4
@@ -388,7 +388,7 @@ importers:
         version: 8.5.1(@swc/core@1.15.3)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
       unplugin-inline-functions:
         specifier: 'catalog:'
-        version: 0.3.0(@babel/parser@7.28.5)(@babel/traverse@7.28.5)(@babel/types@7.28.5)
+        version: 0.3.3(@babel/parser@7.28.5)(@babel/traverse@7.28.5)(@babel/types@7.28.5)
       vitest:
         specifier: 'catalog:'
         version: 4.0.13(@types/node@24.10.1)(jsdom@27.2.0)(tsx@4.21.0)
@@ -2025,8 +2025,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  unplugin-inline-functions@0.3.0:
-    resolution: {integrity: sha512-ylB0svxII2YRpA7CHbUoEwpWm6/9GRNSbnwQmfF2nBQOaH3FaFlQfvEuc6+w+zboGUTvaoZladwoA2ntwD70KQ==}
+  unplugin-inline-functions@0.3.3:
+    resolution: {integrity: sha512-G/q6LmGLxJqmp9Yg/aeIDk6sRQ0Qzd8UuCQu5pBS6gnbnNwJ72aSVsYPGjuLHn3aFjd/twy/bO7CkE/Ts0zRSQ==}
     peerDependencies:
       '@babel/parser': ^7.26.3
       '@babel/traverse': ^7.26.4
@@ -3642,7 +3642,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  unplugin-inline-functions@0.3.0(@babel/parser@7.28.5)(@babel/traverse@7.28.5)(@babel/types@7.28.5):
+  unplugin-inline-functions@0.3.3(@babel/parser@7.28.5)(@babel/traverse@7.28.5)(@babel/types@7.28.5):
     dependencies:
       '@babel/parser': 7.28.5
       '@babel/traverse': 7.28.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   react: ^19.2.0
   react-dom: ^19.2.0
   three: ^0.181.2
-  unplugin-inline-functions: ^0.3.0
+  unplugin-inline-functions: ^0.3.3
   vite: ^7.2.4
   vitest: ^4.0.13
 


### PR DESCRIPTION
When I upgraded the inlining plugin to unplugin, the files stopped being discovered and the inlining was failing. With a few changes to how file discovery works, we are back!