### PR TITLE
chore: Use explicit type imports

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,7 @@
 export { createActions } from './actions/create-actions';
-// Export types
-export * from './actions/types';
+export type { ActionGetter, ActionInitializer, Actions } from './actions/types';
 export { $internal } from './common';
-export * from './entity/types';
+export type { Entity } from './entity/types';
 export { unpackEntity } from './entity/utils/pack-entity';
 export { createAdded } from './query/modifiers/added';
 export { createChanged } from './query/modifiers/changed';
@@ -10,12 +9,44 @@ export { Not } from './query/modifiers/not';
 export { Or } from './query/modifiers/or';
 export { createRemoved } from './query/modifiers/removed';
 export { IsExcluded } from './query/query';
-export * from './query/types';
+export type {
+	EventType,
+	InstancesFromParameters,
+	IsNotModifier,
+	ModifierData,
+	Query,
+	QueryHash,
+	QueryModifier,
+	QueryParameter,
+	QueryResult,
+	QueryResultOptions,
+	QuerySubscriber,
+	QueryUnsubscriber,
+	StoresFromParameters,
+} from './query/types';
 export { cacheQuery } from './query/utils/cache-query';
 export { Pair, relation } from './relation/relation';
-export * from './relation/types';
+export type { Relation, RelationPair, RelationTarget } from './relation/types';
 export { getStore, trait } from './trait/trait';
-export * from './trait/types';
+export type {
+	AoSFactory,
+	ConfigurableTrait,
+	ExtractIsTag,
+	ExtractSchema,
+	ExtractStore,
+	IsTag,
+	Norm,
+	Schema,
+	SetTraitCallback,
+	Store,
+	TagTrait,
+	Trait,
+	TraitData,
+	TraitRecord,
+	TraitTuple,
+	TraitType,
+	TraitValue,
+} from './trait/types';
 export { universe } from './universe/universe';
 export type { World } from './world/world';
 export { createWorld } from './world/world';

--- a/packages/core/src/query/modifiers/added.ts
+++ b/packages/core/src/query/modifiers/added.ts
@@ -1,4 +1,5 @@
 import type { Trait } from '../../trait/types';
+import type { ModifierData } from '../types';
 import { universe } from '../../universe/universe';
 import { createModifier } from '../modifier';
 import { createTrackingId, setTrackingMasks } from '../utils/tracking-cursor';
@@ -11,7 +12,7 @@ export function createAdded() {
 		setTrackingMasks(world, id);
 	}
 
-	return <T extends Trait[] = Trait[]>(...traits: T) => {
+	return <T extends Trait[] = Trait[]>(...traits: T): ModifierData<T, `added-${number}`> => {
 		return createModifier(`added-${id}`, id, traits);
 	};
 }

--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -6,6 +6,7 @@ import type { Trait } from '../../trait/types';
 import { universe } from '../../universe/universe';
 import type { World } from '../../world/world';
 import { getTraitData, hasTraitData } from '../../trait/utils/trait-data';
+import type { ModifierData } from '../types';
 import { createModifier } from '../modifier';
 import { checkQueryTrackingWithRelations } from '../utils/check-query-tracking-with-relations';
 import { createTrackingId, setTrackingMasks } from '../utils/tracking-cursor';
@@ -18,7 +19,7 @@ export function createChanged() {
 		setTrackingMasks(world, id);
 	}
 
-	return <T extends Trait[] = Trait[]>(...traits: T) => {
+	return <T extends Trait[] = Trait[]>(...traits: T): ModifierData<T, `changed-${number}`> => {
 		return createModifier(`changed-${id}`, id, traits);
 	};
 }

--- a/packages/core/src/query/modifiers/not.ts
+++ b/packages/core/src/query/modifiers/not.ts
@@ -1,6 +1,7 @@
 import type { Trait } from '../../trait/types';
+import type { ModifierData } from '../types';
 import { createModifier } from '../modifier';
 
-export const Not = <T extends Trait[] = Trait[]>(...traits: T) => {
+export const Not = <T extends Trait[] = Trait[]>(...traits: T): ModifierData<T, 'not'> => {
 	return createModifier('not', 1, traits);
 };

--- a/packages/core/src/query/modifiers/or.ts
+++ b/packages/core/src/query/modifiers/or.ts
@@ -1,6 +1,7 @@
 import type { Trait } from '../../trait/types';
+import type { ModifierData } from '../types';
 import { createModifier } from '../modifier';
 
-export const Or = <T extends Trait[] = Trait[]>(...traits: T) => {
+export const Or = <T extends Trait[] = Trait[]>(...traits: T): ModifierData<T, 'or'> => {
 	return createModifier('or', 2, traits);
 };

--- a/packages/core/src/query/modifiers/removed.ts
+++ b/packages/core/src/query/modifiers/removed.ts
@@ -1,4 +1,5 @@
 import type { Trait } from '../../trait/types';
+import type { ModifierData } from '../types';
 import { universe } from '../../universe/universe';
 import { createModifier } from '../modifier';
 import { createTrackingId, setTrackingMasks } from '../utils/tracking-cursor';
@@ -11,7 +12,7 @@ export function createRemoved() {
 		setTrackingMasks(world, id);
 	}
 
-	return <T extends Trait[] = Trait[]>(...traits: T) => {
+	return <T extends Trait[] = Trait[]>(...traits: T): ModifierData<T, `removed-${number}`> => {
 		return createModifier(`removed-${id}`, id, traits);
 	};
 }

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -4,7 +4,7 @@ import { getEntityId } from '../entity/utils/pack-entity';
 import { isRelationPair } from '../relation/relation';
 import type { Relation } from '../relation/types';
 import { registerTrait, trait } from '../trait/trait';
-import type { Trait, TraitData } from '../trait/types';
+import type { TagTrait, Trait, TraitData } from '../trait/types';
 import { SparseSet } from '../utils/sparse-set';
 import type { World } from '../world/world';
 import { isModifier } from './modifier';
@@ -16,7 +16,7 @@ import { checkQueryWithRelations } from './utils/check-query-with-relations';
 import { createQueryHash } from './utils/create-query-hash';
 import { getTraitData, hasTraitData } from '../trait/utils/trait-data';
 
-export const IsExcluded = trait();
+export const IsExcluded: TagTrait = trait();
 
 export function runQuery<T extends QueryParameter[]>(world: World, query: Query<T>): QueryResult<T> {
 	commitQueryRemovals(world);

--- a/packages/react/src/world/use-world.ts
+++ b/packages/react/src/world/use-world.ts
@@ -1,7 +1,8 @@
 import { useContext } from 'react';
+import type { World } from '@koota/core';
 import { WorldContext } from './world-context';
 
-export function useWorld() {
+export function useWorld(): World {
 	const world = useContext(WorldContext);
 
 	if (!world) {


### PR DESCRIPTION
This helps with resolving the types with bundling. Types are easier to analyze and dedupe.