### PR TITLE
fix: `useTag` and `useHas` return `false` for undefined entity

### DIFF
--- a/packages/react/src/hooks/use-has.ts
+++ b/packages/react/src/hooks/use-has.ts
@@ -14,18 +14,28 @@ export function useHas(target: Entity | World | undefined | null, trait: Trait):
 	);
 
 	// Initialize the state with whether the entity has the tag.
-	const [value, setValue] = useState<boolean | undefined>(() => {
+	const [value, setValue] = useState<boolean>(() => {
 		return memo?.entity.has(trait) ?? false;
 	});
 
 	// Subscribe to add/remove events for the tag.
 	useEffect(() => {
-		if (!memo) return;
-		const unsubscribe = memo.subscribe(setValue);
-		return () => unsubscribe();
+		if (!memo) {
+			setValue(false);
+			return;
+		}
+
+		const unsubscribe = memo.subscribe((value) => {
+			setValue(value ?? false);
+		});
+
+		return () => {
+			unsubscribe();
+			setValue(false);
+		};
 	}, [memo]);
 
-	return value ?? false;
+	return value;
 }
 
 function createSubscriptions(target: Entity | World, trait: Trait, contextWorld: World) {

--- a/packages/react/src/hooks/use-tag.ts
+++ b/packages/react/src/hooks/use-tag.ts
@@ -14,18 +14,28 @@ export function useTag(target: Entity | World | undefined | null, tag: TagTrait)
 	);
 
 	// Initialize the state with whether the entity has the tag.
-	const [value, setValue] = useState<boolean | undefined>(() => {
+	const [value, setValue] = useState<boolean>(() => {
 		return memo?.entity.has(tag) ?? false;
 	});
 
 	// Subscribe to add/remove events for the tag.
 	useEffect(() => {
-		if (!memo) return;
-		const unsubscribe = memo.subscribe(setValue);
-		return () => unsubscribe();
+		if (!memo) {
+			setValue(false);
+			return;
+		}
+
+		const unsubscribe = memo.subscribe((value) => {
+			setValue(value ?? false);
+		});
+
+		return () => {
+			unsubscribe();
+			setValue(false);
+		};
 	}, [memo]);
 
-	return value ?? false;
+	return value;
 }
 
 function createSubscriptions(target: Entity | World, tag: TagTrait, contextWorld: World) {

--- a/packages/react/tests/trait.test.tsx
+++ b/packages/react/tests/trait.test.tsx
@@ -246,6 +246,40 @@ describe('useTag', () => {
 		expect(isTagged).toBe(false);
 	});
 
+	it('returns false when the target becomes undefined', async () => {
+		let entity: Entity | undefined = world.spawn(IsTagged);
+
+		let isTagged: boolean | undefined;
+
+		function Test() {
+			isTagged = useTag(entity, IsTagged);
+			return null;
+		}
+
+		const { rerender } = render(
+			<StrictMode>
+				<WorldProvider world={world}>
+					<Test />
+				</WorldProvider>
+			</StrictMode>
+		);
+
+		expect(isTagged).toBe(true);
+
+		await act(async () => {
+			entity = undefined;
+			rerender(
+				<StrictMode>
+					<WorldProvider world={world}>
+						<Test />
+					</WorldProvider>
+				</StrictMode>
+			);
+		});
+
+		expect(isTagged).toBe(false);
+	});
+
 	it('works with a world', async () => {
 		const IsPaused = trait();
 		world.add(IsPaused);
@@ -305,6 +339,40 @@ describe('useHas', () => {
 
 		await act(async () => {
 			entity.remove(Position);
+		});
+
+		expect(hasPosition).toBe(false);
+	});
+
+	it('returns false when the target becomes undefined', async () => {
+		let entity: Entity | undefined = world.spawn(Position);
+
+		let hasPosition: boolean | undefined;
+
+		function Test() {
+			hasPosition = useHas(entity, Position);
+			return null;
+		}
+
+		const { rerender } = render(
+			<StrictMode>
+				<WorldProvider world={world}>
+					<Test />
+				</WorldProvider>
+			</StrictMode>
+		);
+
+		expect(hasPosition).toBe(true);
+
+		await act(async () => {
+			entity = undefined;
+			rerender(
+				<StrictMode>
+					<WorldProvider world={world}>
+						<Test />
+					</WorldProvider>
+				</StrictMode>
+			);
 		});
 
 		expect(hasPosition).toBe(false);


### PR DESCRIPTION
If `useTag` or `useHas` receive an undefined entity they will return `false`. Before it was returning whatever the cached value was. Bad!