### PR TITLE
fix: Query updateEach works if the param order changes

### DIFF
--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -22,10 +22,13 @@ import type {
 export function createQueryResult<T extends QueryParameter[]>(
 	world: World,
 	entities: Entity[],
-	query: QueryInstance
+	query: QueryInstance,
+	params: QueryParameter[]
 ): QueryResult<T> {
-	const traits = [...query.resultTraits];
-	const stores = [...query.resultStores];
+	const traits: Trait[] = [];
+	const stores: Store<any>[] = [];
+
+	getQueryStores(params, traits, stores, world);
 
 	const results = Object.assign(entities, {
 		updateEach(

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -29,7 +29,8 @@ export const IsExcluded: TagTrait = trait();
 
 export function runQuery<T extends QueryParameter[]>(
 	world: World,
-	query: QueryInstance<T>
+	query: QueryInstance<T>,
+	params: QueryParameter[]
 ): QueryResult<T> {
 	commitQueryRemovals(world);
 
@@ -46,7 +47,7 @@ export function runQuery<T extends QueryParameter[]>(
 		}
 	}
 
-	return createQueryResult(world, entities, query);
+	return createQueryResult(world, entities, query, params);
 }
 
 export function addEntityToQuery(query: QueryInstance, entity: Entity) {
@@ -110,8 +111,6 @@ export function createQueryInstance<T extends QueryParameter[]>(
 		parameters,
 		hash: '',
 		traits: [],
-		resultStores: [],
-		resultTraits: [],
 		traitInstances: {
 			required: [],
 			forbidden: [],
@@ -132,7 +131,7 @@ export function createQueryInstance<T extends QueryParameter[]>(
 		removeSubscriptions: new Set<QuerySubscriber>(),
 		relationFilters: [],
 
-		run: (world: World) => runQuery(world, query),
+		run: (world: World, params: QueryParameter[]) => runQuery(world, query, params),
 		add: (entity: Entity) => addEntityToQuery(query, entity),
 		remove: (world: World, entity: Entity) => removeEntityFromQuery(world, query, entity),
 		check: (world: World, entity: Entity) => checkQuery(world, query, entity),
@@ -413,9 +412,6 @@ export function createQueryInstance<T extends QueryParameter[]>(
 			if (match) query.add(entity);
 		}
 	}
-
-	// Pre-compute result stores and traits.
-	getQueryStores(parameters, query.resultTraits, query.resultStores, world);
 
 	return query;
 }

--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -101,8 +101,6 @@ export type QueryInstance<T extends QueryParameter[] = QueryParameter[]> = {
 	parameters: T;
 	hash: QueryHash;
 	traits: Trait[];
-	resultStores: Store[];
-	resultTraits: Trait[];
 	traitInstances: {
 		required: TraitInstance[];
 		forbidden: TraitInstance[];
@@ -133,7 +131,7 @@ export type QueryInstance<T extends QueryParameter[] = QueryParameter[]> = {
 	removeSubscriptions: Set<QuerySubscriber>;
 	/** Relation pairs for target-specific queries */
 	relationFilters?: RelationPair[];
-	run: (world: World) => QueryResult<T>;
+	run: (world: World, params: QueryParameter[]) => QueryResult<T>;
 	add: (entity: Entity) => void;
 	remove: (world: World, entity: Entity) => void;
 	check: (world: World, entity: Entity) => boolean;

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -171,12 +171,12 @@ export function createWorld(
 		query(...args: any[]) {
 			const ctx = world[$internal];
 
-			// Check if first arg is a QueryRef (has symbol brand)
+			// Check if first arg is a QueryRef
 			if (args.length === 1 && isQuery(args[0])) {
 				const queryRef = args[0];
-				// Try array lookup first (faster)
+				// Try array lookup first
 				let query = ctx.queryInstances[queryRef.id];
-				if (query) return query.run(world);
+				if (query) return query.run(world, queryRef.parameters);
 
 				// Fallback to hash map
 				query = ctx.queriesHashMap.get(queryRef.hash);
@@ -189,7 +189,7 @@ export function createWorld(
 					}
 					ctx.queryInstances[queryRef.id] = query;
 				}
-				return query.run(world);
+				return query.run(world, queryRef.parameters);
 			} else {
 				const params = args as QueryParameter[];
 
@@ -218,7 +218,7 @@ export function createWorld(
 					ctx.queriesHashMap.set(hash, query);
 				}
 
-				return query.run(world);
+				return query.run(world, params);
 			}
 		},
 

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -260,6 +260,27 @@ describe('Query', () => {
 		expect(cb).toHaveBeenCalledTimes(9);
 	});
 
+	it('updateEach should return values in caller parameter order regardless of cache', () => {
+		// Create entity with both traits
+		const entity = world.spawn(Position({ x: 10, y: 20 }), Name({ name: 'test' }));
+
+		// First query with order: Position, Name
+		world.query(Position, Name).updateEach(([position, name]) => {
+			expect(position).toHaveProperty('x');
+			expect(position).toHaveProperty('y');
+			expect(name).toHaveProperty('name');
+			expect(name.name).toBe('test');
+		});
+
+		// Second query with REVERSED order: Name, Position
+		// This should return values in the order specified (Name first, Position second)
+		world.query(Name, Position).updateEach(([name, position]) => {
+			expect(name).toHaveProperty('name', 'test');
+			expect(position).toHaveProperty('x');
+			expect(position).toHaveProperty('y');
+		});
+	});
+
 	it('should return the first entity in a query', () => {
 		const entityA = world.spawn(Position);
 


### PR DESCRIPTION
I had done some caching on queries a while back that assumes the parameter order never changes. This would cause `updateEach` to return traits in the order the first call cached, even if another query changed the order. This undoes the caching for correct behavior.