### PR TITLE
refactor: Queries no longer eagerly register

### DIFF
--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -436,17 +436,7 @@ export function createQuery<T extends QueryParameter[]>(...parameters: T): Query
 		parameters,
 	}) as Query<T>;
 
-	for (const world of universe.worlds) {
-		if (!world) continue;
-
-		const ctx = world[$internal];
-
-		if (!ctx.queriesHashMap.has(hash)) {
-			const query = createQueryInstance(world, parameters);
-			ctx.queriesHashMap.set(hash, query);
-		}
-	}
-
+	// Cache the ref for deduplication and stable IDs
 	universe.cachedQueries.set(hash, queryRef);
 
 	return queryRef;

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -73,12 +73,6 @@ export function createWorld(
 			// Register system traits.
 			if (!hasTraitInstance(ctx.traitInstances, IsExcluded)) registerTrait(world, IsExcluded);
 
-			// Create cached queries.
-			for (const [hash, queryRef] of universe.cachedQueries) {
-				const query = createQueryInstance(world, queryRef.parameters);
-				ctx.queriesHashMap.set(hash, query);
-			}
-
 			// Create world entity.
 			ctx.worldEntity = createEntity(world, IsExcluded, ...initTraits);
 		},
@@ -156,12 +150,6 @@ export function createWorld(
 
 			// Create new world entity.
 			ctx.worldEntity = createEntity(world, IsExcluded);
-
-			// Restore cached queries.
-			for (const [hash, queryRef] of universe.cachedQueries) {
-				const query = createQueryInstance(world, queryRef.parameters);
-				ctx.queriesHashMap.set(hash, query);
-			}
 
 			for (const sub of ctx.resetSubscriptions) {
 				sub(world);

--- a/packages/react/src/hooks/use-query.ts
+++ b/packages/react/src/hooks/use-query.ts
@@ -11,14 +11,14 @@ export function useQuery<T extends QueryParameter[]>(...parameters: T): QueryRes
 	// This will rerun every render since parameters will always be a fresh
 	// array, but the return value will be stable.
 	const queryRef = useMemo(() => createQuery(...parameters), [parameters]);
+	// Registers the query with the world.
+	const [entities, setEntities] = useState<QueryResult<T>>(() => world.query(queryRef).sort());
 
-	useMemo(() => {
+	initialQueryVersionRef.current = useMemo(() => {
 		// Using internals to get the query data.
 		const query = world[$internal].queriesHashMap.get(queryRef.hash)!;
-		initialQueryVersionRef.current = query.version;
+		return query.version;
 	}, [world, queryRef]);
-
-	const [entities, setEntities] = useState<QueryResult<T>>(() => world.query(queryRef).sort());
 
 	// Subscribe to changes.
 	useEffect(() => {


### PR DESCRIPTION
Queries were eagerly registering to worlds, making a bad coupling with the universe and also requiring the world reset to reach into the universe. This was all a smell, so I moved queries to be entirely lazy registered on first use. I can reintroduce an eager registration later but this would be an explicit API call.