### PR TITLE
fix: `useTrait` always re-renders with `entity.change()`

### DIFF
--- a/packages/react/src/hooks/use-trait.ts
+++ b/packages/react/src/hooks/use-trait.ts
@@ -10,19 +10,17 @@ export function useTrait<T extends Trait>(
     const contextWorld = useWorld();
     const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
     const valueRef = useRef<TraitRecord<T> | undefined>(undefined);
+    const memoRef = useRef<ReturnType<typeof createSubscriptions<T>> | undefined>(undefined);
 
     const memo = useMemo(
         () => (target ? createSubscriptions(target, trait, contextWorld) : undefined),
         [target, trait, contextWorld]
     );
 
-    // Initialize the cached value when memo changes
-    if (memo) {
-        if (valueRef.current === undefined && memo.entity.has(trait)) {
-            valueRef.current = memo.entity.get(trait);
-        }
-    } else {
-        valueRef.current = undefined;
+    // Update cached value when the target or trait changes
+    if (memoRef.current !== memo) {
+        memoRef.current = memo;
+        valueRef.current = memo?.entity.has(trait) ? memo.entity.get(trait) : undefined;
     }
 
     useEffect(() => {


### PR DESCRIPTION
There was a bug reported by a user that `useTrait` was failing to re-render when an AoS trait was marked as changed with `entity.changed()`. This was because while the changed callback fired, the internal `useState` saw the same object ref for the returned value and decided it did not need to re-rerender. We now force a re-render using `useReducer` whenever a change event occurs. 

Closes https://github.com/pmndrs/koota/issues/150