### PR TITLE
fix: Modifier trait types correctly work in `updateEach`

### DIFF
--- a/packages/core/src/query/modifiers/added.ts
+++ b/packages/core/src/query/modifiers/added.ts
@@ -1,23 +1,25 @@
 import { $internal } from '../../common';
 import { isRelation } from '../../relation/utils/is-relation';
-import type { Trait, TraitOrRelation } from '../../trait/types';
+import type { ExtractTraits, TraitOrRelation } from '../../trait/types';
 import { universe } from '../../universe/universe';
 import { createModifier } from '../modifier';
 import type { Modifier } from '../types';
 import { createTrackingId, setTrackingMasks } from '../utils/tracking-cursor';
 
 export function createAdded() {
-	const id = createTrackingId();
+    const id = createTrackingId();
 
-	for (const world of universe.worlds) {
-		if (!world) continue;
-		setTrackingMasks(world, id);
-	}
+    for (const world of universe.worlds) {
+        if (!world) continue;
+        setTrackingMasks(world, id);
+    }
 
-	return <T extends TraitOrRelation[] = TraitOrRelation[]>(
-		...inputs: T
-	): Modifier<Trait[], `added-${number}`> => {
-		const traits = inputs.map((input) => (isRelation(input) ? input[$internal].trait : input));
-		return createModifier(`added-${id}`, id, traits);
-	};
+    return <T extends TraitOrRelation[]>(
+        ...inputs: T
+    ): Modifier<ExtractTraits<T>, `added-${number}`> => {
+        const traits = inputs.map((input) =>
+            isRelation(input) ? input[$internal].trait : input
+        ) as ExtractTraits<T>;
+        return createModifier(`added-${id}`, id, traits);
+    };
 }

--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -4,7 +4,7 @@ import { getEntityId } from '../../entity/utils/pack-entity';
 import { isRelation } from '../../relation/utils/is-relation';
 import { hasTrait, registerTrait } from '../../trait/trait';
 import { getTraitInstance, hasTraitInstance } from '../../trait/trait-instance';
-import type { Trait, TraitOrRelation } from '../../trait/types';
+import type { ExtractTraits, Trait, TraitOrRelation } from '../../trait/types';
 import { universe } from '../../universe/universe';
 import type { World } from '../../world';
 import { createModifier } from '../modifier';
@@ -13,73 +13,75 @@ import { checkQueryTrackingWithRelations } from '../utils/check-query-tracking-w
 import { createTrackingId, setTrackingMasks } from '../utils/tracking-cursor';
 
 export function createChanged() {
-	const id = createTrackingId();
+    const id = createTrackingId();
 
-	for (const world of universe.worlds) {
-		if (!world) continue;
-		setTrackingMasks(world, id);
-	}
+    for (const world of universe.worlds) {
+        if (!world) continue;
+        setTrackingMasks(world, id);
+    }
 
-	return <T extends TraitOrRelation[] = TraitOrRelation[]>(
-		...inputs: T
-	): Modifier<Trait[], `changed-${number}`> => {
-		const traits = inputs.map((input) => (isRelation(input) ? input[$internal].trait : input));
-		return createModifier(`changed-${id}`, id, traits);
-	};
+    return <T extends TraitOrRelation[]>(
+        ...inputs: T
+    ): Modifier<ExtractTraits<T>, `changed-${number}`> => {
+        const traits = inputs.map((input) =>
+            isRelation(input) ? input[$internal].trait : input
+        ) as ExtractTraits<T>;
+        return createModifier(`changed-${id}`, id, traits);
+    };
 }
 
 /** @inline */
 function markChanged(world: World, entity: Entity, trait: Trait) {
-	const ctx = world[$internal];
+    const ctx = world[$internal];
 
-	// Early exit if the trait is not on the entity.
-	if (!hasTrait(world, entity, trait)) return;
+    // Early exit if the trait is not on the entity.
+    if (!hasTrait(world, entity, trait)) return;
 
-	// Register the trait if it's not already registered.
-	if (!hasTraitInstance(ctx.traitInstances, trait)) registerTrait(world, trait);
-	const data = getTraitInstance(ctx.traitInstances, trait)!;
+    // Register the trait if it's not already registered.
+    if (!hasTraitInstance(ctx.traitInstances, trait)) registerTrait(world, trait);
+    const data = getTraitInstance(ctx.traitInstances, trait)!;
 
-	// Mark the trait as changed in bitmasks for Changed modifiers.
-	const eid = getEntityId(entity);
-	const { generationId, bitflag } = data;
+    // Mark the trait as changed in bitmasks for Changed modifiers.
+    const eid = getEntityId(entity);
+    const { generationId, bitflag } = data;
 
-	for (const changedMask of ctx.changedMasks.values()) {
-		if (!changedMask[generationId]) changedMask[generationId] = [];
-		if (!changedMask[generationId][eid]) changedMask[generationId][eid] = 0;
-		changedMask[generationId][eid] |= bitflag;
-	}
+    for (const changedMask of ctx.changedMasks.values()) {
+        if (!changedMask[generationId]) changedMask[generationId] = [];
+        if (!changedMask[generationId][eid]) changedMask[generationId][eid] = 0;
+        changedMask[generationId][eid] |= bitflag;
+    }
 
-	// Update tracking queries with change event
-	for (const query of data.trackingQueries) {
-		if (!query.hasChangedModifiers) continue;
-		if (!query.changedTraits.has(trait)) continue;
+    // Update tracking queries with change event
+    for (const query of data.trackingQueries) {
+        if (!query.hasChangedModifiers) continue;
+        if (!query.changedTraits.has(trait)) continue;
 
-		const match =
-			query.relationFilters && query.relationFilters.length > 0
-				? checkQueryTrackingWithRelations(
-						world,
-						query,
-						entity,
-						'change',
-						generationId,
-						bitflag
-				  )
-				: query.checkTracking(world, entity, 'change', generationId, bitflag);
-		if (match) query.add(entity);
-		else query.remove(world, entity);
-	}
+        const match =
+            query.relationFilters && query.relationFilters.length > 0
+                ? checkQueryTrackingWithRelations(
+                      world,
+                      query,
+                      entity,
+                      'change',
+                      generationId,
+                      bitflag
+                  )
+                : query.checkTracking(world, entity, 'change', generationId, bitflag);
+        if (match) query.add(entity);
+        else query.remove(world, entity);
+    }
 
-	return data;
+    return data;
 }
 
 export function setChanged(world: World, entity: Entity, trait: Trait) {
-	const data = markChanged(world, entity, trait);
-	if (!data) return;
-	for (const sub of data.changeSubscriptions) sub(entity);
+    const data = markChanged(world, entity, trait);
+    if (!data) return;
+    for (const sub of data.changeSubscriptions) sub(entity);
 }
 
 export function setPairChanged(world: World, entity: Entity, trait: Trait, target: Entity) {
-	const data = markChanged(world, entity, trait);
-	if (!data) return;
-	for (const sub of data.changeSubscriptions) sub(entity, target);
+    const data = markChanged(world, entity, trait);
+    if (!data) return;
+    for (const sub of data.changeSubscriptions) sub(entity, target);
 }

--- a/packages/core/src/query/modifiers/removed.ts
+++ b/packages/core/src/query/modifiers/removed.ts
@@ -1,23 +1,25 @@
 import { $internal } from '../../common';
 import { isRelation } from '../../relation/utils/is-relation';
-import type { Trait, TraitOrRelation } from '../../trait/types';
+import type { ExtractTraits, TraitOrRelation } from '../../trait/types';
 import { universe } from '../../universe/universe';
 import { createModifier } from '../modifier';
 import type { Modifier } from '../types';
 import { createTrackingId, setTrackingMasks } from '../utils/tracking-cursor';
 
 export function createRemoved() {
-	const id = createTrackingId();
+    const id = createTrackingId();
 
-	for (const world of universe.worlds) {
-		if (!world) continue;
-		setTrackingMasks(world, id);
-	}
+    for (const world of universe.worlds) {
+        if (!world) continue;
+        setTrackingMasks(world, id);
+    }
 
-	return <T extends TraitOrRelation[] = TraitOrRelation[]>(
-		...inputs: T
-	): Modifier<Trait[], `removed-${number}`> => {
-		const traits = inputs.map((input) => (isRelation(input) ? input[$internal].trait : input));
-		return createModifier(`removed-${id}`, id, traits);
-	};
+    return <T extends TraitOrRelation[]>(
+        ...inputs: T
+    ): Modifier<ExtractTraits<T>, `removed-${number}`> => {
+        const traits = inputs.map((input) =>
+            isRelation(input) ? input[$internal].trait : input
+        ) as ExtractTraits<T>;
+        return createModifier(`removed-${id}`, id, traits);
+    };
 }

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -8,52 +8,52 @@ import type { AoSFactory, Schema, Store, StoreType } from '../storage';
 export type TraitType = StoreType;
 
 export type TraitValue<TSchema extends Schema> = TSchema extends AoSFactory
-	? ReturnType<TSchema>
-	: Partial<TraitRecord<TSchema>>;
+    ? ReturnType<TSchema>
+    : Partial<TraitRecord<TSchema>>;
 
 export type Trait<TSchema extends Schema = any> = {
-	/** Public read-only ID for fast array lookups */
-	readonly id: number;
-	readonly schema: TSchema;
-	[$internal]: {
-		set: (index: number, store: any, value: TraitValue<TSchema>) => void;
-		fastSet: (index: number, store: any, value: TraitValue<TSchema>) => boolean;
-		fastSetWithChangeDetection: (
-			index: number,
-			store: any,
-			value: TraitValue<TSchema>
-		) => boolean;
-		get: (index: number, store: any) => TraitRecord<TSchema>;
-		id: number;
-		createStore: () => Store<TSchema>;
-		/** Reference to parent relation if this trait is owned by a relation */
-		relation: Relation<any> | null;
-		type: StoreType;
-	};
+    /** Public read-only ID for fast array lookups */
+    readonly id: number;
+    readonly schema: TSchema;
+    [$internal]: {
+        set: (index: number, store: any, value: TraitValue<TSchema>) => void;
+        fastSet: (index: number, store: any, value: TraitValue<TSchema>) => boolean;
+        fastSetWithChangeDetection: (
+            index: number,
+            store: any,
+            value: TraitValue<TSchema>
+        ) => boolean;
+        get: (index: number, store: any) => TraitRecord<TSchema>;
+        id: number;
+        createStore: () => Store<TSchema>;
+        /** Reference to parent relation if this trait is owned by a relation */
+        relation: Relation<any> | null;
+        type: StoreType;
+    };
 } & ((params?: TraitValue<TSchema>) => [Trait<TSchema>, TraitValue<TSchema>]);
 
 export type TagTrait = Trait<Record<string, never>> & { [$internal]: { type: 'tag' } };
 
 export type TraitTuple<T extends Trait = Trait> = [
-	T,
-	T extends Trait<infer S>
-		? S extends AoSFactory
-			? ReturnType<S>
-			: Partial<TraitRecord<S>>
-		: never
+    T,
+    T extends Trait<infer S>
+        ? S extends AoSFactory
+            ? ReturnType<S>
+            : Partial<TraitRecord<S>>
+        : never
 ];
 
 export type ConfigurableTrait<T extends Trait = Trait> = T | TraitTuple<T> | RelationPair<T>;
 
 export type SetTraitCallback<T extends Trait | RelationPair> = (
-	prev: TraitRecord<ExtractSchema<T>>
+    prev: TraitRecord<ExtractSchema<T>>
 ) => TraitValue<ExtractSchema<T>>;
 
 type TraitRecordFromSchema<T extends Schema> = T extends AoSFactory
-	? ReturnType<T>
-	: {
-			[P in keyof T]: T[P] extends (...args: never[]) => unknown ? ReturnType<T[P]> : T[P];
-	  };
+    ? ReturnType<T>
+    : {
+          [P in keyof T]: T[P] extends (...args: never[]) => unknown ? ReturnType<T[P]> : T[P];
+      };
 
 /**
  * The record of a trait.
@@ -61,49 +61,57 @@ type TraitRecordFromSchema<T extends Schema> = T extends AoSFactory
  * For AoS it is the state instance for a single entity.
  */
 export type TraitRecord<T extends Trait | Schema> = T extends Trait
-	? TraitRecordFromSchema<T['schema']>
-	: TraitRecordFromSchema<T>;
+    ? TraitRecordFromSchema<T['schema']>
+    : TraitRecordFromSchema<T>;
 
 // Type Utils
 
 export type ExtractSchema<T extends Trait | Relation<Trait> | RelationPair> = T extends RelationPair<
-	infer R
+    infer R
 >
-	? ExtractSchema<R>
-	: T extends Relation<infer R>
-	? ExtractSchema<R>
-	: T extends Trait<infer S>
-	? S
-	: never;
+    ? ExtractSchema<R>
+    : T extends Relation<infer R>
+    ? ExtractSchema<R>
+    : T extends Trait<infer S>
+    ? S
+    : never;
 export type ExtractStore<T extends Trait> = T extends { [$internal]: { createStore(): infer Store } }
-	? Store
-	: never;
+    ? Store
+    : never;
 export type ExtractIsTag<T extends Trait> = T extends { [$internal]: { type: 'tag' } } ? true : false;
 
 export type IsTag<T extends Trait> = ExtractIsTag<T>;
 
 export interface TraitInstance<T extends Trait = Trait, S extends Schema = ExtractSchema<T>> {
-	generationId: number;
-	bitflag: number;
-	trait: Trait;
-	store: Store<S>;
-	/** Non-tracking queries that include this trait */
-	queries: Set<QueryInstance>;
-	/** Tracking queries (Added/Removed/Changed) that include this trait */
-	trackingQueries: Set<QueryInstance>;
-	notQueries: Set<QueryInstance>;
-	/** Queries that filter by this relation (only for relation traits) */
-	relationQueries: Set<QueryInstance>;
-	schema: S;
-	changeSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
-	addSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
-	removeSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
-	/**
-	 * Only for relation traits.
-	 * For exclusive: relationTargets[eid] = targetId (number)
-	 * For non-exclusive: relationTargets[eid] = [targetId1, targetId2, ...] (number[])
-	 */
-	relationTargets?: number[] | number[][];
+    generationId: number;
+    bitflag: number;
+    trait: Trait;
+    store: Store<S>;
+    /** Non-tracking queries that include this trait */
+    queries: Set<QueryInstance>;
+    /** Tracking queries (Added/Removed/Changed) that include this trait */
+    trackingQueries: Set<QueryInstance>;
+    notQueries: Set<QueryInstance>;
+    /** Queries that filter by this relation (only for relation traits) */
+    relationQueries: Set<QueryInstance>;
+    schema: S;
+    changeSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
+    addSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
+    removeSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
+    /**
+     * Only for relation traits.
+     * For exclusive: relationTargets[eid] = targetId (number)
+     * For non-exclusive: relationTargets[eid] = [targetId1, targetId2, ...] (number[])
+     */
+    relationTargets?: number[] | number[][];
 }
 
 export type TraitOrRelation = Trait | Relation<Trait>;
+
+/** Extracts the underlying Trait from a TraitOrRelation (Relations contain a Trait) */
+export type ExtractTrait<T> = T extends Relation<infer TTrait> ? TTrait : T;
+
+/** Maps a tuple of TraitOrRelation to their underlying Traits */
+export type ExtractTraits<T extends TraitOrRelation[]> = {
+    [K in keyof T]: ExtractTrait<T[K]>;
+};

--- a/packages/core/tests/query-modifiers.test.ts
+++ b/packages/core/tests/query-modifiers.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
-	$internal,
-	createAdded,
-	createChanged,
-	createRemoved,
-	createWorld,
-	getStore,
-	Not,
-	trait,
+    $internal,
+    createAdded,
+    createChanged,
+    createRemoved,
+    createWorld,
+    getStore,
+    Not,
+    trait,
 } from '../src';
 
 const Position = trait({ x: 0, y: 0 });
@@ -16,499 +16,562 @@ const Foo = trait();
 const Bar = trait();
 
 describe('Query modifiers', () => {
-	const world = createWorld();
-	world.init();
+    const world = createWorld();
+    world.init();
 
-	beforeEach(() => {
-		world.reset();
-	});
+    beforeEach(() => {
+        world.reset();
+    });
 
-	it('should correctly populate Not queries when traits are added and removed', () => {
-		const entityA = world.spawn();
-		const entityB = world.spawn();
-		const entityC = world.spawn();
+    it('should correctly populate Not queries when traits are added and removed', () => {
+        const entityA = world.spawn();
+        const entityB = world.spawn();
+        const entityC = world.spawn();
 
-		let entities: any = world.query(Foo);
-		expect(entities.length).toBe(0);
+        let entities: any = world.query(Foo);
+        expect(entities.length).toBe(0);
 
-		entities = world.query(Not(Foo));
-		expect(entities[0]).toBe(entityA);
-		expect(entities[1]).toBe(entityB);
-		expect(entities[2]).toBe(entityC);
+        entities = world.query(Not(Foo));
+        expect(entities[0]).toBe(entityA);
+        expect(entities[1]).toBe(entityB);
+        expect(entities[2]).toBe(entityC);
 
-		// Add
-		entityA.add(Foo);
-		entityB.add(Bar);
-		entityC.add(Foo, Bar);
+        // Add
+        entityA.add(Foo);
+        entityB.add(Bar);
+        entityC.add(Foo, Bar);
 
-		entities = world.query(Foo);
-		expect(entities[0]).toBe(entityA);
-		expect(entities[1]).toBe(entityC);
+        entities = world.query(Foo);
+        expect(entities[0]).toBe(entityA);
+        expect(entities[1]).toBe(entityC);
 
-		entities = world.query(Foo, Bar);
-		expect(entities[0]).toBe(entityC);
+        entities = world.query(Foo, Bar);
+        expect(entities[0]).toBe(entityC);
 
-		entities = world.query(Not(Foo));
-		expect(entities[0]).toBe(entityB);
+        entities = world.query(Not(Foo));
+        expect(entities[0]).toBe(entityB);
 
-		// Remove
-		entityA.remove(Foo);
+        // Remove
+        entityA.remove(Foo);
 
-		entities = world.query(Foo);
-		expect(entities[0]).toBe(entityC);
+        entities = world.query(Foo);
+        expect(entities[0]).toBe(entityC);
 
-		entities = world.query(Not(Foo));
-		expect(entities[0]).toBe(entityB);
-		expect(entities[1]).toBe(entityA);
+        entities = world.query(Not(Foo));
+        expect(entities[0]).toBe(entityB);
+        expect(entities[1]).toBe(entityA);
 
-		entities = world.query(Not(Foo), Not(Bar));
-		expect(entities[0]).toBe(entityA);
+        entities = world.query(Not(Foo), Not(Bar));
+        expect(entities[0]).toBe(entityA);
 
-		// Remove more so entity A and C have no traits
-		entityC.remove(Foo);
-		entityC.remove(Bar);
+        // Remove more so entity A and C have no traits
+        entityC.remove(Foo);
+        entityC.remove(Bar);
 
-		entities = world.query(Not(Foo), Not(Bar));
-		expect(entities.length).toBe(2);
+        entities = world.query(Not(Foo), Not(Bar));
+        expect(entities.length).toBe(2);
 
-		entities = world.query(Not(Foo));
-		expect(entities.length).toBe(3);
-	});
+        entities = world.query(Not(Foo));
+        expect(entities.length).toBe(3);
+    });
 
-	it('modifiers can be added as one call or separately', () => {
-		const ctx = world[$internal];
-		const entity = world.spawn();
-		entity.add(Position, IsActive);
+    it('modifiers can be added as one call or separately', () => {
+        const ctx = world[$internal];
+        const entity = world.spawn();
+        entity.add(Position, IsActive);
 
-		let entities: any = world.query(Not(Foo), Not(Bar));
-		expect(entities.length).toBe(1);
+        let entities: any = world.query(Not(Foo), Not(Bar));
+        expect(entities.length).toBe(1);
 
-		entities = world.query(Not(Foo, Bar));
-		expect(entities.length).toBe(1);
+        entities = world.query(Not(Foo, Bar));
+        expect(entities.length).toBe(1);
 
-		// These queries should be hashed the same.
-		expect(ctx.queriesHashMap.size).toBe(1);
-	});
+        // These queries should be hashed the same.
+        expect(ctx.queriesHashMap.size).toBe(1);
+    });
 
-	it('should correctly populate Added queries when traits are added', () => {
-		const Added = createAdded();
+    it('should correctly populate Added queries when traits are added', () => {
+        const Added = createAdded();
 
-		const entityA = world.spawn();
-		const entityB = world.spawn();
-		const entityC = world.spawn();
+        const entityA = world.spawn();
+        const entityB = world.spawn();
+        const entityC = world.spawn();
 
-		let entities: readonly number[] = [];
+        let entities: readonly number[] = [];
 
-		entities = world.query(Added(Foo));
-		expect(entities.length).toBe(0);
+        entities = world.query(Added(Foo));
+        expect(entities.length).toBe(0);
 
-		entityA.add(Foo);
-		entities = world.query(Added(Foo));
-		expect(entities[0]).toBe(entityA);
+        entityA.add(Foo);
+        entities = world.query(Added(Foo));
+        expect(entities[0]).toBe(entityA);
 
-		// The query gets drained and should be empty when run again.
-		entities = world.query(Added(Foo));
-		expect(entities.length).toBe(0);
+        // The query gets drained and should be empty when run again.
+        entities = world.query(Added(Foo));
+        expect(entities.length).toBe(0);
 
-		entityB.add(Foo);
-		entities = world.query(Added(Foo));
-		expect(entities[0]).toBe(entityB);
+        entityB.add(Foo);
+        entities = world.query(Added(Foo));
+        expect(entities[0]).toBe(entityB);
 
-		// And a static query should give both entities.
-		entities = world.query(Foo);
-		expect(entities[0]).toBe(entityA);
-		expect(entities[1]).toBe(entityB);
-
-		// Should not be added to the query if the trait is removed before it is read.
-		entityC.add(Foo);
-		entityC.remove(Foo);
-		entities = world.query(Added(Foo));
-		expect(entities.length).toBe(0);
+        // And a static query should give both entities.
+        entities = world.query(Foo);
+        expect(entities[0]).toBe(entityA);
+        expect(entities[1]).toBe(entityB);
+
+        // Should not be added to the query if the trait is removed before it is read.
+        entityC.add(Foo);
+        entityC.remove(Foo);
+        entities = world.query(Added(Foo));
+        expect(entities.length).toBe(0);
 
-		// But if it is removed and added again in the same frame it should be recorded.
-		entityA.remove(Foo);
-		entityA.add(Foo);
-		entities = world.query(Added(Foo));
-		expect(entities[0]).toBe(entityA);
+        // But if it is removed and added again in the same frame it should be recorded.
+        entityA.remove(Foo);
+        entityA.add(Foo);
+        entities = world.query(Added(Foo));
+        expect(entities[0]).toBe(entityA);
 
-		// Should only populate the query if tracked trait is added,
-		// even if it matches the query otherwise.
-		entityA.remove(Foo, Bar); // Quick reset
-		entityA.add(Foo);
-		world.query(Added(Foo)); // Drain query
+        // Should only populate the query if tracked trait is added,
+        // even if it matches the query otherwise.
+        entityA.remove(Foo, Bar); // Quick reset
+        entityA.add(Foo);
+        world.query(Added(Foo)); // Drain query
 
-		entityA.add(Bar);
-		entities = world.query(Added(Foo));
-		expect(entities.length).toBe(0); // Fails for Added
-		entities = world.query(Foo, Bar);
-		expect(entities[0]).toBe(entityA); // But matches static query
-	});
-
-	it('should properly populate Added queries with mulitple tracked traits', () => {
-		const Added = createAdded();
-
-		const entityA = world.spawn();
-		const entityB = world.spawn();
-
-		let entities = world.query(Added(Foo, Bar));
-		expect(entities.length).toBe(0);
+        entityA.add(Bar);
+        entities = world.query(Added(Foo));
+        expect(entities.length).toBe(0); // Fails for Added
+        entities = world.query(Foo, Bar);
+        expect(entities[0]).toBe(entityA); // But matches static query
+    });
+
+    it('should properly populate Added queries with mulitple tracked traits', () => {
+        const Added = createAdded();
+
+        const entityA = world.spawn();
+        const entityB = world.spawn();
+
+        let entities = world.query(Added(Foo, Bar));
+        expect(entities.length).toBe(0);
 
-		entityA.add(Foo);
-		entities = world.query(Added(Foo, Bar));
-		expect(entities.length).toBe(0);
+        entityA.add(Foo);
+        entities = world.query(Added(Foo, Bar));
+        expect(entities.length).toBe(0);
 
-		entityA.add(Bar);
-		entities = world.query(Added(Foo, Bar));
-		expect(entities[0]).toBe(entityA);
+        entityA.add(Bar);
+        entities = world.query(Added(Foo, Bar));
+        expect(entities[0]).toBe(entityA);
 
-		entityB.add(Foo);
-		entities = world.query(Added(Foo, Bar));
-		expect(entities.length).toBe(0);
+        entityB.add(Foo);
+        entities = world.query(Added(Foo, Bar));
+        expect(entities.length).toBe(0);
 
-		entityB.add(Bar);
-		entities = world.query(Added(Foo, Bar));
-		expect(entities[0]).toBe(entityB);
-	});
-
-	it('should track multiple Added modifiers independently', () => {
-		const Added = createAdded();
-		const Added2 = createAdded();
-
-		const entityA = world.spawn();
-		const entityB = world.spawn();
-
-		let entities = world.query(Added(Foo));
-		expect(entities.length).toBe(0);
-
-		let entities2 = world.query(Added2(Foo));
-		expect(entities2.length).toBe(0);
-
-		entityA.add(Foo);
-		entities = world.query(Added(Foo));
-		expect(entities.length).toBe(1);
-
-		entityB.remove(Foo);
-		entityB.add(Foo);
-		entities = world.query(Added(Foo));
-		entities2 = world.query(Added2(Foo));
-
-		expect(entities.length).toBe(1);
-		expect(entities2.length).toBe(2);
-	});
-
-	it('should populate Added queries even if they are registered after the trait is added', () => {
-		const Added = createAdded();
-
-		const entityA = world.spawn(Foo);
-		const entityB = world.spawn(Foo, Bar);
+        entityB.add(Bar);
+        entities = world.query(Added(Foo, Bar));
+        expect(entities[0]).toBe(entityB);
+    });
+
+    it('should track multiple Added modifiers independently', () => {
+        const Added = createAdded();
+        const Added2 = createAdded();
+
+        const entityA = world.spawn();
+        const entityB = world.spawn();
+
+        let entities = world.query(Added(Foo));
+        expect(entities.length).toBe(0);
+
+        let entities2 = world.query(Added2(Foo));
+        expect(entities2.length).toBe(0);
+
+        entityA.add(Foo);
+        entities = world.query(Added(Foo));
+        expect(entities.length).toBe(1);
+
+        entityB.remove(Foo);
+        entityB.add(Foo);
+        entities = world.query(Added(Foo));
+        entities2 = world.query(Added2(Foo));
+
+        expect(entities.length).toBe(1);
+        expect(entities2.length).toBe(2);
+    });
+
+    it('should populate Added queries even if they are registered after the trait is added', () => {
+        const Added = createAdded();
+
+        const entityA = world.spawn(Foo);
+        const entityB = world.spawn(Foo, Bar);
 
-		let entities: any = world.query(Added(Foo));
-		expect(entities[0]).toBe(entityA);
-		expect(entities[1]).toBe(entityB);
+        let entities: any = world.query(Added(Foo));
+        expect(entities[0]).toBe(entityA);
+        expect(entities[1]).toBe(entityB);
 
-		entities = world.query(Added(Foo, Bar));
-		expect(entities[0]).toBe(entityB);
+        entities = world.query(Added(Foo, Bar));
+        expect(entities[0]).toBe(entityB);
 
-		const LaterAdded = createAdded();
+        const LaterAdded = createAdded();
 
-		let entities2 = world.query(LaterAdded(Foo));
-		expect(entities2.length).toBe(0);
+        let entities2 = world.query(LaterAdded(Foo));
+        expect(entities2.length).toBe(0);
 
-		entityA.remove(Foo); // Reset
-		entityA.add(Foo);
-		entities = world.query(Added(Foo));
-		entities2 = world.query(LaterAdded(Foo));
+        entityA.remove(Foo); // Reset
+        entityA.add(Foo);
+        entities = world.query(Added(Foo));
+        entities2 = world.query(LaterAdded(Foo));
 
-		expect(entities.length).toBe(1);
-		expect(entities2.length).toBe(1);
-	});
+        expect(entities.length).toBe(1);
+        expect(entities2.length).toBe(1);
+    });
 
-	it('should combine Not and Added modifiers with logical AND', () => {
-		const Added = createAdded();
+    it('should combine Not and Added modifiers with logical AND', () => {
+        const Added = createAdded();
 
-		const entityA = world.spawn();
-		const entityB = world.spawn();
+        const entityA = world.spawn();
+        const entityB = world.spawn();
 
-		// No entities should match this query since while Not will match
-		// all empty entities, Added will only match entities that have Foo.
-		let entities = world.query(Added(Foo), Not(Bar));
-		expect(entities.length).toBe(0);
-
-		// Adding Foo to entityA should match the query as it has Foo added and not Bar.
-		entityA.add(Foo);
-		entities = world.query(Added(Foo), Not(Bar));
-		expect(entities[0]).toBe(entityA);
-
-		// Adding Foo and Bar to entityB should not match the query as it has Bar.
-		entityB.add(Foo, Bar);
-		entities = world.query(Added(Foo), Not(Bar));
-		expect(entities.length).toBe(0);
-	});
-
-	it('should properly populate Removed queries when traits are removed', () => {
-		const Removed = createRemoved();
-
-		const entityA = world.spawn();
-		const entityB = world.spawn();
-
-		let entities = world.query(Removed(Foo));
-		expect(entities.length).toBe(0);
-
-		entityA.add(Foo);
-		entityB.add(Foo);
-		entities = world.query(Removed(Foo));
-		expect(entities.length).toBe(0);
-
-		entityA.remove(Foo);
-		entities = world.query(Removed(Foo));
-		expect(entities[0]).toBe(entityA);
-
-		// Should work with traits added and removed in the same frame.
-		entityA.add(Foo);
-		entityA.remove(Foo);
-		entities = world.query(Removed(Foo));
-		expect(entities[0]).toBe(entityA);
-		// Should track between Removed modifiers independently.
-		const Removed2 = createRemoved();
-
-		let entities2 = world.query(Removed2(Foo));
-		expect(entities2.length).toBe(0);
-
-		entityA.add(Foo);
-		entityA.remove(Foo);
-		entities = world.query(Removed(Foo));
-		expect(entities.length).toBe(1);
-
-		entityB.add(Foo);
-		entityB.remove(Foo);
-		entities = world.query(Removed(Foo));
-		entities2 = world.query(Removed2(Foo));
-
-		expect(entities.length).toBe(1);
-		expect(entities2.length).toBe(2);
-	});
-
-	it('should populate Removed queries even if they are registered after the trait is removed', () => {
-		const Removed = createRemoved();
-
-		const entity = world.spawn(Foo);
-		entity.remove(Foo);
-
-		let entities = world.query(Removed(Foo));
-		expect(entities[0]).toBe(entity);
-
-		entity.add(Foo); // Reset
-
-		const LaterRemoved = createRemoved();
-
-		let entities2 = world.query(LaterRemoved(Foo));
-		expect(entities2.length).toBe(0);
-
-		entity.remove(Foo);
-		entities = world.query(Removed(Foo));
-		entities2 = world.query(LaterRemoved(Foo));
-
-		expect(entities.length).toBe(1);
-		expect(entities2.length).toBe(1);
-	});
-
-	it('should combine Not and Removed modifiers with logical AND', () => {
-		const Removed = createRemoved();
-
-		const entityA = world.spawn();
-		const entityB = world.spawn();
-
-		// Initially, no entities should match the query because no entities
-		// have Foo removed even though Not matches all empty entities.
-		let entities = world.query(Removed(Foo), Not(Bar));
-		expect(entities.length).toBe(0);
-
-		// Add Foo to entityA, then it should not match as it hasn't been removed yet.
-		entityA.add(Foo);
-		entities = world.query(Removed(Foo), Not(Bar));
-		expect(entities.length).toBe(0);
-
-		// Add Foo and Bar to entityB, it also should not match as
-		// Foo hasn't been removed and it has Bar.
-		entityB.add(Foo, Bar);
-		entities = world.query(Removed(Foo), Not(Bar));
-		expect(entities.length).toBe(0);
-
-		// Remove Foo from entityA, it should now match as Foo is removed and
-		// it does not have Bar.
-		entityA.remove(Foo);
-		entities = world.query(Removed(Foo), Not(Bar));
-		expect(entities[0]).toBe(entityA);
-
-		// Remove Foo from entityB, it should still not match as it has Bar.
-		entityB.remove(Foo);
-		entities = world.query(Removed(Foo), Not(Bar));
-		expect(entities.length).toBe(0);
-	});
-
-	it('should combine Added and Removed modifiers with logical AND', () => {
-		const Added = createAdded();
-		const Removed = createRemoved();
-
-		const entityA = world.spawn();
-		const entityB = world.spawn();
-
-		let entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities.length).toBe(0);
-
-		// Add Foo to entityA and Bar to entityB.
-		// Neither entity should match the query.
-		entityA.add(Foo);
-		entityB.add(Bar);
-		entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities.length).toBe(0);
-
-		// Remove Foo from entityA and remove Bar from entityB.
-		// Neither entity should match the query.
-		entityA.remove(Foo);
-		entityB.remove(Bar);
-		entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities.length).toBe(0);
-
-		// Add Foo and Bar to entityA, then remove Bar.
-		// This entity should now match the query.
-		entityA.add(Foo, Bar);
-		entityA.remove(Bar);
-		entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities[0]).toBe(entityA);
-
-		// Resets and can fill again.
-		entityA.remove(Foo);
-		entityA.add(Foo);
-		entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities.length).toBe(0);
-
-		// Add Foo to entityB and remove Bar.
-		// This entity should now match the query.
-		entityB.add(Foo, Bar);
-		entityB.remove(Bar);
-		entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities[0]).toBe(entityB);
-
-		// Make sure changes in one entity do not leak to the other.
-		const entityC = world.spawn();
-		const entityD = world.spawn();
-
-		entityC.add(Foo);
-		entityD.add(Bar);
-		entityD.remove(Bar);
-
-		entities = world.query(Added(Foo), Removed(Bar));
-		expect(entities.length).toBe(0);
-	});
-
-	it('should properly populate Changed queries when traits are changed', () => {
-		const Changed = createChanged();
-
-		const entityA = world.spawn();
-
-		let entities = world.query(Changed(Position));
-		expect(entities.length).toBe(0);
-
-		entityA.add(Position);
-		entities = world.query(Changed(Position));
-		expect(entities.length).toBe(0);
-
-		const positions = getStore(world, Position);
-		positions.x[entityA] = 10;
-		positions.y[entityA] = 20;
-
-		// Set changed should populate the query.
-		entityA.changed(Position);
-		entities = world.query(Changed(Position));
-		expect(entities[0]).toBe(entityA);
-
-		// Querying again should not return the entity.
-		entities = world.query(Changed(Position));
-		expect(entities.length).toBe(0);
-
-		// Should not populate the query if the trait is removed.
-		entityA.remove(Position);
-		entityA.changed(Position);
-		entities = world.query(Changed(Position));
-		expect(entities.length).toBe(0);
-	});
-
-	it('should populate Changed queries even if they are registered after the trait is changed', () => {
-		const Changed = createChanged();
-
-		const entity = world.spawn(Position);
-
-		const positions = getStore(world, Position);
-		positions.x[entity] = 10;
-		positions.y[entity] = 20;
-		entity.changed(Position);
-
-		let entities = world.query(Changed(Position));
-		// expect(entities).toEqual([entity]);
-
-		const LaterChanged = createChanged();
-
-		let entities2 = world.query(LaterChanged(Position));
-		expect(entities2.length).toBe(0);
-
-		positions.x[entity] = 30;
-		positions.y[entity] = 40;
-		entity.changed(Position);
-
-		entities = world.query(Changed(Position));
-		entities2 = world.query(LaterChanged(Position));
-
-		expect(entities.length).toBe(1);
-		expect(entities2.length).toBe(1);
-	});
-
-	it('should only update a Changed query when the tracked trait is changed', () => {
-		const entity = world.spawn(Foo, Bar);
-
-		const Changed = createChanged();
-
-		expect(world.queryFirst(Changed(Foo), Changed(Bar))).toBeUndefined();
-
-		entity.changed(Foo);
-		entity.changed(Bar);
-		expect(world.queryFirst(Changed(Foo), Changed(Bar))).toBe(entity);
-
-		entity.changed(Foo);
-		expect(world.queryFirst(Changed(Foo), Changed(Bar))).toBeUndefined();
-	});
-
-	// @see https://github.com/pmndrs/koota/issues/115
-	it('should not trigger Changed query when removing a different trait', () => {
-		const Changed = createChanged();
-		const entity = world.spawn(Position);
-
-		// Initial state - no changes
-		expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
-
-		// Change Position
-		entity.changed(Position);
-		expect(world.queryFirst(Changed(Position), Not(Foo))).toBe(entity);
-
-		// Query again - should be empty
-		expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
-
-		// Add and remove Foo - should be empty
-		entity.add(Foo);
-		entity.remove(Foo);
-		expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
-	});
-
-	it('should correctly populate Changed query when trait changes happen before query initialization', () => {
-		// Create change modifier and spawn an entity
-		const Changed = createChanged();
-		const entity = world.spawn(Foo, Bar);
-
-		// Mark Bar as changed
-		entity.changed(Bar);
-
-		// Even if the query wasn't executed before,
-		// it should pick up the trait change
-		expect(world.queryFirst(Changed(Bar))).toBe(entity);
-	});
+        // No entities should match this query since while Not will match
+        // all empty entities, Added will only match entities that have Foo.
+        let entities = world.query(Added(Foo), Not(Bar));
+        expect(entities.length).toBe(0);
+
+        // Adding Foo to entityA should match the query as it has Foo added and not Bar.
+        entityA.add(Foo);
+        entities = world.query(Added(Foo), Not(Bar));
+        expect(entities[0]).toBe(entityA);
+
+        // Adding Foo and Bar to entityB should not match the query as it has Bar.
+        entityB.add(Foo, Bar);
+        entities = world.query(Added(Foo), Not(Bar));
+        expect(entities.length).toBe(0);
+    });
+
+    it('should properly populate Removed queries when traits are removed', () => {
+        const Removed = createRemoved();
+
+        const entityA = world.spawn();
+        const entityB = world.spawn();
+
+        let entities = world.query(Removed(Foo));
+        expect(entities.length).toBe(0);
+
+        entityA.add(Foo);
+        entityB.add(Foo);
+        entities = world.query(Removed(Foo));
+        expect(entities.length).toBe(0);
+
+        entityA.remove(Foo);
+        entities = world.query(Removed(Foo));
+        expect(entities[0]).toBe(entityA);
+
+        // Should work with traits added and removed in the same frame.
+        entityA.add(Foo);
+        entityA.remove(Foo);
+        entities = world.query(Removed(Foo));
+        expect(entities[0]).toBe(entityA);
+        // Should track between Removed modifiers independently.
+        const Removed2 = createRemoved();
+
+        let entities2 = world.query(Removed2(Foo));
+        expect(entities2.length).toBe(0);
+
+        entityA.add(Foo);
+        entityA.remove(Foo);
+        entities = world.query(Removed(Foo));
+        expect(entities.length).toBe(1);
+
+        entityB.add(Foo);
+        entityB.remove(Foo);
+        entities = world.query(Removed(Foo));
+        entities2 = world.query(Removed2(Foo));
+
+        expect(entities.length).toBe(1);
+        expect(entities2.length).toBe(2);
+    });
+
+    it('should populate Removed queries even if they are registered after the trait is removed', () => {
+        const Removed = createRemoved();
+
+        const entity = world.spawn(Foo);
+        entity.remove(Foo);
+
+        let entities = world.query(Removed(Foo));
+        expect(entities[0]).toBe(entity);
+
+        entity.add(Foo); // Reset
+
+        const LaterRemoved = createRemoved();
+
+        let entities2 = world.query(LaterRemoved(Foo));
+        expect(entities2.length).toBe(0);
+
+        entity.remove(Foo);
+        entities = world.query(Removed(Foo));
+        entities2 = world.query(LaterRemoved(Foo));
+
+        expect(entities.length).toBe(1);
+        expect(entities2.length).toBe(1);
+    });
+
+    it('should combine Not and Removed modifiers with logical AND', () => {
+        const Removed = createRemoved();
+
+        const entityA = world.spawn();
+        const entityB = world.spawn();
+
+        // Initially, no entities should match the query because no entities
+        // have Foo removed even though Not matches all empty entities.
+        let entities = world.query(Removed(Foo), Not(Bar));
+        expect(entities.length).toBe(0);
+
+        // Add Foo to entityA, then it should not match as it hasn't been removed yet.
+        entityA.add(Foo);
+        entities = world.query(Removed(Foo), Not(Bar));
+        expect(entities.length).toBe(0);
+
+        // Add Foo and Bar to entityB, it also should not match as
+        // Foo hasn't been removed and it has Bar.
+        entityB.add(Foo, Bar);
+        entities = world.query(Removed(Foo), Not(Bar));
+        expect(entities.length).toBe(0);
+
+        // Remove Foo from entityA, it should now match as Foo is removed and
+        // it does not have Bar.
+        entityA.remove(Foo);
+        entities = world.query(Removed(Foo), Not(Bar));
+        expect(entities[0]).toBe(entityA);
+
+        // Remove Foo from entityB, it should still not match as it has Bar.
+        entityB.remove(Foo);
+        entities = world.query(Removed(Foo), Not(Bar));
+        expect(entities.length).toBe(0);
+    });
+
+    it('should combine Added and Removed modifiers with logical AND', () => {
+        const Added = createAdded();
+        const Removed = createRemoved();
+
+        const entityA = world.spawn();
+        const entityB = world.spawn();
+
+        let entities = world.query(Added(Foo), Removed(Bar));
+        expect(entities.length).toBe(0);
+
+        // Add Foo to entityA and Bar to entityB.
+        // Neither entity should match the query.
+        entityA.add(Foo);
+        entityB.add(Bar);
+        entities = world.query(Added(Foo), Removed(Bar));
+        expect(entities.length).toBe(0);
+
+        // Remove Foo from entityA and remove Bar from entityB.
+        // Neither entity should match the query.
+        entityA.remove(Foo);
+        entityB.remove(Bar);
+        entities = world.query(Added(Foo), Removed(Bar));
+        expect(entities.length).toBe(0);
+
+        // Add Foo and Bar to entityA, then remove Bar.
+        // This entity should now match the query.
+        entityA.add(Foo, Bar);
+        entityA.remove(Bar);
+        entities = world.query(Added(Foo), Removed(Bar));
+        expect(entities[0]).toBe(entityA);
+
+        // Resets and can fill again.
+        entityA.remove(Foo);
+        entityA.add(Foo);
+        entities = world.query(Added(Foo), Removed(Bar));
+        expect(entities.length).toBe(0);
+
+        // Add Foo to entityB and remove Bar.
+        // This entity should now match the query.
+        entityB.add(Foo, Bar);
+        entityB.remove(Bar);
+        entities = world.query(Added(Foo), Removed(Bar));
+        expect(entities[0]).toBe(entityB);
+
+        // Make sure changes in one entity do not leak to the other.
+        const entityC = world.spawn();
+        const entityD = world.spawn();
+
+        entityC.add(Foo);
+        entityD.add(Bar);
+        entityD.remove(Bar);
+
+        entities = world.query(Added(Foo), Removed(Bar));
+        expect(entities.length).toBe(0);
+    });
+
+    it('should properly populate Changed queries when traits are changed', () => {
+        const Changed = createChanged();
+
+        const entityA = world.spawn();
+
+        let entities = world.query(Changed(Position));
+        expect(entities.length).toBe(0);
+
+        entityA.add(Position);
+        entities = world.query(Changed(Position));
+        expect(entities.length).toBe(0);
+
+        const positions = getStore(world, Position);
+        positions.x[entityA] = 10;
+        positions.y[entityA] = 20;
+
+        // Set changed should populate the query.
+        entityA.changed(Position);
+        entities = world.query(Changed(Position));
+        expect(entities[0]).toBe(entityA);
+
+        // Querying again should not return the entity.
+        entities = world.query(Changed(Position));
+        expect(entities.length).toBe(0);
+
+        // Should not populate the query if the trait is removed.
+        entityA.remove(Position);
+        entityA.changed(Position);
+        entities = world.query(Changed(Position));
+        expect(entities.length).toBe(0);
+    });
+
+    it('should populate Changed queries even if they are registered after the trait is changed', () => {
+        const Changed = createChanged();
+
+        const entity = world.spawn(Position);
+
+        const positions = getStore(world, Position);
+        positions.x[entity] = 10;
+        positions.y[entity] = 20;
+        entity.changed(Position);
+
+        let entities = world.query(Changed(Position));
+        // expect(entities).toEqual([entity]);
+
+        const LaterChanged = createChanged();
+
+        let entities2 = world.query(LaterChanged(Position));
+        expect(entities2.length).toBe(0);
+
+        positions.x[entity] = 30;
+        positions.y[entity] = 40;
+        entity.changed(Position);
+
+        entities = world.query(Changed(Position));
+        entities2 = world.query(LaterChanged(Position));
+
+        expect(entities.length).toBe(1);
+        expect(entities2.length).toBe(1);
+    });
+
+    it('should only update a Changed query when the tracked trait is changed', () => {
+        const entity = world.spawn(Foo, Bar);
+
+        const Changed = createChanged();
+
+        expect(world.queryFirst(Changed(Foo), Changed(Bar))).toBeUndefined();
+
+        entity.changed(Foo);
+        entity.changed(Bar);
+        expect(world.queryFirst(Changed(Foo), Changed(Bar))).toBe(entity);
+
+        entity.changed(Foo);
+        expect(world.queryFirst(Changed(Foo), Changed(Bar))).toBeUndefined();
+    });
+
+    // @see https://github.com/pmndrs/koota/issues/115
+    it('should not trigger Changed query when removing a different trait', () => {
+        const Changed = createChanged();
+        const entity = world.spawn(Position);
+
+        // Initial state - no changes
+        expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
+
+        // Change Position
+        entity.changed(Position);
+        expect(world.queryFirst(Changed(Position), Not(Foo))).toBe(entity);
+
+        // Query again - should be empty
+        expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
+
+        // Add and remove Foo - should be empty
+        entity.add(Foo);
+        entity.remove(Foo);
+        expect(world.queryFirst(Changed(Position), Not(Foo))).toBeUndefined();
+    });
+
+    it('should correctly populate Changed query when trait changes happen before query initialization', () => {
+        // Create change modifier and spawn an entity
+        const Changed = createChanged();
+        const entity = world.spawn(Foo, Bar);
+
+        // Mark Bar as changed
+        entity.changed(Bar);
+
+        // Even if the query wasn't executed before,
+        // it should pick up the trait change
+        expect(world.queryFirst(Changed(Bar))).toBe(entity);
+    });
+
+    it('updateEach should work with Added modifier', () => {
+        const Added = createAdded();
+        const entity = world.spawn(Position({ x: 10, y: 20 }));
+
+        world.query(Added(Position)).updateEach(([position]) => {
+            expect(position).toHaveProperty('x', 10);
+            expect(position).toHaveProperty('y', 20);
+            position.x = 100;
+        });
+
+        expect(entity.get(Position)!.x).toBe(100);
+    });
+
+    it('updateEach should work with Added modifier combined with other traits', () => {
+        const Added = createAdded();
+        const Name = trait({ name: '' });
+        const entity = world.spawn(Position({ x: 5, y: 15 }), Name({ name: 'test' }));
+
+        world.query(Added(Position), Name).updateEach(([position, name]) => {
+            expect(position).toHaveProperty('x', 5);
+            expect(position).toHaveProperty('y', 15);
+            expect(name).toHaveProperty('name', 'test');
+            position.x = 50;
+            name.name = 'updated';
+        });
+
+        expect(entity.get(Position)!.x).toBe(50);
+        expect(entity.get(Name)!.name).toBe('updated');
+    });
+
+    it('updateEach should work with Changed modifier', () => {
+        const Changed = createChanged();
+        const entity = world.spawn(Position({ x: 1, y: 2 }));
+
+        entity.changed(Position);
+
+        world.query(Changed(Position)).updateEach(([position]) => {
+            expect(position).toHaveProperty('x', 1);
+            expect(position).toHaveProperty('y', 2);
+            position.x = 10;
+        });
+
+        expect(entity.get(Position)!.x).toBe(10);
+    });
+
+    it('updateEach should work with Removed modifier', () => {
+        const Removed = createRemoved();
+        const Name = trait({ name: '' });
+        const entity = world.spawn(Position({ x: 7, y: 8 }), Name({ name: 'keep' }));
+
+        entity.remove(Position);
+
+        // Removed modifier includes the removed trait in stores, plus any other queried traits
+        world.query(Removed(Position), Name).updateEach(([position, name]) => {
+            // Position data may still be accessible (stale) even after removal
+            expect(position).toHaveProperty('x');
+            expect(name).toHaveProperty('name', 'keep');
+            name.name = 'modified';
+        });
+
+        expect(entity.get(Name)!.name).toBe('modified');
+    });
 });


### PR DESCRIPTION
We had this issue where modifier traits were being ignored by TS in `updateEach` even though the values were being passed properly.

```js
world.query(Added(Foo)).updateEach(([foo]) => {
// Typescript says foo is undefined here, but it's Foo
})

world.query(Added(Foo), Bar).updateEach(([foo, bar]) => {
// Typescript says foo is Bar here and that bar is undefined
})
```

This is now fixed!
