### PR TITLE
fix: Changed modifier always works when entity generations overflow

### DIFF
--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -377,16 +377,17 @@ export function createQueryInstance<T extends QueryParameter[]>(
 							traitMatches =
 								(oldMask & bitflag) === 0 && (currentMask & bitflag) === bitflag;
 							break;
-						case 'remove':
-							traitMatches =
-								((oldMask & bitflag) === bitflag && (currentMask & bitflag) === 0) ||
-								((oldMask & bitflag) === 0 &&
-									(currentMask & bitflag) === 0 &&
-									(dirtyMask[generationId][eid] & bitflag) === bitflag);
-							break;
-						case 'change':
-							traitMatches = (changedMask[generationId][eid] & bitflag) === bitflag;
-							break;
+					case 'remove':
+						traitMatches =
+							((oldMask & bitflag) === bitflag && (currentMask & bitflag) === 0) ||
+							((oldMask & bitflag) === 0 &&
+								(currentMask & bitflag) === 0 &&
+								((dirtyMask[generationId]?.[eid] ?? 0) & bitflag) === bitflag);
+						break;
+					case 'change':
+						traitMatches =
+							((changedMask[generationId]?.[eid] ?? 0) & bitflag) === bitflag;
+						break;
 					}
 
 					if (!traitMatches) {


### PR DESCRIPTION
Fixes https://github.com/pmndrs/koota/issues/151

There was race condition possible between a changed modifier and query initializing that had to do with world's entity generation overflowing before the query was initialized. We add some defensive code during the query initialization to fix this.