### PR TITLE
feat: add autoDestroy behavior to relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,14 @@ inventory.set(Contains(gold), { amount: 20 })
 const data = inventory.get(Contains(gold)) // { amount: 20 }
 ```
 
-#### Auto remove target
+#### Auto destroy
 
-Relations can automatically remove target entities and their descendants.
+Relations can automatically destroy related entities when their counterpart is destroyed using the `autoDestroy` option.
+
+**Destroy orphans.** When a target is destroyed, destroy all sources pointing to it. This is commonly used for hierarchies when you want to clean up any detached graphs. It can be enabled with the `'orphan'` or `'target'` option.
 
 ```js
-const ChildOf = relation({ autoRemoveTarget: true })
+const ChildOf = relation({ autoDestroy: 'orphan' }) // Or 'target'
 
 const parent = world.spawn()
 const child = world.spawn(ChildOf(parent))
@@ -199,6 +201,21 @@ const grandchild = world.spawn(ChildOf(child))
 parent.destroy()
 
 world.has(child) // False, the child and grandchild are destroyed too
+```
+
+**Destroy targets.** When a source is destroyed, destroy all its targets.
+
+```js
+const Contains = relation({ autoDestroy: 'target' })
+
+const container = world.spawn()
+const itemA = world.spawn()
+const itemB = world.spawn()
+
+container.add(Contains(itemA), Contains(itemB))
+container.destroy()
+
+world.has(itemA) // False, items are destroyed with container
 ```
 
 #### Exclusive relations

--- a/examples/apps/revade/src/traits/index.ts
+++ b/examples/apps/revade/src/traits/index.ts
@@ -54,7 +54,7 @@ export const IsPlayer = trait();
 export const IsShieldVisible = trait();
 export const ShieldVisibility = trait({ duration: 1400, current: 0 });
 
-export const FiredBy = relation({ autoRemoveTarget: true });
+export const FiredBy = relation({ autoDestroy: 'orphan' });
 export const Targeting = relation({ exclusive: true });
 
 export const SpatialHashMap = trait(() => new SpatialHashMapImpl(50));

--- a/packages/core/src/relation/types.ts
+++ b/packages/core/src/relation/types.ts
@@ -21,7 +21,7 @@ export type Relation<T extends Trait = Trait> = {
     [$internal]: {
         trait: T;
         exclusive: boolean;
-        autoRemoveTarget: boolean;
+        autoDestroy: 'source' | 'target' | false;
     };
 } & ((target: RelationTarget, params?: Record<string, unknown>) => RelationPair<T>);
 

--- a/packages/core/tests/ordered.test.ts
+++ b/packages/core/tests/ordered.test.ts
@@ -276,8 +276,8 @@ describe('Ordered relations', () => {
         expect(childrenB[0]).toBe(child2);
     });
 
-    it('should clean up relations when destroying entity with ordered trait and autoRemoveTarget', () => {
-        const ChildOf = relation({ autoRemoveTarget: true });
+    it('should clean up relations when destroying entity with ordered trait and autoDestroy orphan', () => {
+        const ChildOf = relation({ autoDestroy: 'orphan' });
         const OrderedChildren = ordered(ChildOf);
 
         // Setup hierarchy: grandparent -> parent -> child
@@ -289,7 +289,7 @@ describe('Ordered relations', () => {
         expect(world.query(ChildOf(grandparent))).toContain(parent);
         expect(world.query(ChildOf(grandparent))).toHaveLength(1);
 
-        // Destroy parent - cascades to child via autoRemoveTarget
+        // Destroy parent - cascades to child via autoDestroy: 'orphan'
         parent.destroy();
 
         // Parent and child should be destroyed

--- a/packages/core/tests/relation.test.ts
+++ b/packages/core/tests/relation.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { $internal, createWorld, Not, relation, trait } from '../src';
+import { createWorld, Not, relation, trait } from '../src';
 
 describe('Relation', () => {
     const world = createWorld();
@@ -77,8 +77,8 @@ describe('Relation', () => {
         expect(goblin.targetFor(Targeting)).toBe(undefined);
     });
 
-    it('should auto remove target and its descendants', () => {
-        const ChildOf = relation({ autoRemoveTarget: true });
+    it('should destroy orphaned sources when autoDestroy is orphan', () => {
+        const ChildOf = relation({ autoDestroy: 'orphan' });
 
         const parent = world.spawn();
         const child = world.spawn(ChildOf(parent));
@@ -100,6 +100,26 @@ describe('Relation', () => {
         expect(world.has(childChildA)).toBe(false);
         expect(world.has(childChildB)).toBe(false);
         expect(world.has(childChildC)).toBe(false);
+    });
+
+    it('should destroy targets when autoDestroy is target', () => {
+        const Contains = relation({ autoDestroy: 'target' });
+
+        const container = world.spawn();
+        const itemA = world.spawn();
+        const itemB = world.spawn();
+
+        container.add(Contains(itemA), Contains(itemB));
+
+        expect(world.has(container)).toBe(true);
+        expect(world.has(itemA)).toBe(true);
+        expect(world.has(itemB)).toBe(true);
+
+        container.destroy();
+
+        expect(world.has(container)).toBe(false);
+        expect(world.has(itemA)).toBe(false);
+        expect(world.has(itemB)).toBe(false);
     });
 
     it('should create stores for relations', () => {

--- a/packages/core/tests/world.test.ts
+++ b/packages/core/tests/world.test.ts
@@ -31,9 +31,9 @@ describe('World', () => {
         expect(world.entities.length).toBe(1);
     });
 
-    it('reset should remove entities with auto-remove relations', () => {
+    it('reset should remove entities with auto-destroy relations', () => {
         const Node = trait();
-        const ChildOf = relation({ autoRemoveTarget: true, exclusive: true });
+        const ChildOf = relation({ autoDestroy: 'orphan', exclusive: true });
 
         const world = createWorld();
 
@@ -49,9 +49,9 @@ describe('World', () => {
         expect(world.entities.length).toBe(1);
     });
 
-    it('destroy should lead to entities with auto-remove relations being removed as well', () => {
+    it('destroy should lead to entities with auto-destroy relations being removed as well', () => {
         const Node = trait();
-        const ChildOf = relation({ autoRemoveTarget: true, exclusive: true });
+        const ChildOf = relation({ autoDestroy: 'orphan', exclusive: true });
 
         const world = createWorld();
 


### PR DESCRIPTION
`autoRemoveTargets` has always been a confusing option. It is now clarified as `autoDestroy` with the options `'orphan' | 'source' | 'target'` where orphan and source are aliases for each other. Also, deprecates `autoRemoveTargets`.