### PR TITLE
fix: Structural changes to ordered relations flag changes

### DIFF
--- a/packages/core/src/trait/trait.ts
+++ b/packages/core/src/trait/trait.ts
@@ -127,7 +127,7 @@ export function registerTrait(world: World, trait: Trait) {
 
 function getOrderedTrait(world: World, entity: Entity, trait: OrderedRelation): OrderedList {
     const relation = getOrderedTraitRelation(trait);
-    return new OrderedList(world, entity, relation);
+    return new OrderedList(world, entity, relation, trait);
 }
 
 export function addTrait(world: World, entity: Entity, ...traits: ConfigurableTrait[]) {


### PR DESCRIPTION
Whenever an ordered list gets a structural change (adding, removing or moving an entity) it now flags a change allowing for reactivity. Fixes `useTrait` not working with ordered relations, for example.