### PR TITLE
fix: useQuery could error when a relation target changes

### DIFF
--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -424,9 +424,7 @@ export function createQuery<T extends QueryParameter[]>(...parameters: T): Query
 
     // Check if this query was already cached
     const existing = universe.cachedQueries.get(hash);
-    if (existing) {
-        return existing as Query<T>;
-    }
+    if (existing) return existing as Query<T>;
 
     // Create new query ref with ID
     const id = queryId++;

--- a/packages/react/src/hooks/use-has.ts
+++ b/packages/react/src/hooks/use-has.ts
@@ -1,41 +1,42 @@
 import { $internal, Trait, type Entity, type World } from '@koota/core';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
 import { isWorld } from '../utils/is-world';
 import { useWorld } from '../world/use-world';
 
 export function useHas(target: Entity | World | undefined | null, trait: Trait): boolean {
     const contextWorld = useWorld();
+    const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
     const memo = useMemo(
         () => (target ? createSubscriptions(target, trait, contextWorld) : undefined),
         [target, trait, contextWorld]
     );
 
-    const [value, setValue] = useState<boolean>(() => {
-        return memo?.entity.has(trait) ?? false;
-    });
-
-    // Track memo changes and compute correct value for this render
+    const valueRef = useRef<boolean>(false);
     const memoRef = useRef(memo);
 
-    let currentValue = value;
+    // Update cached value when memo changes
     if (memoRef.current !== memo) {
         memoRef.current = memo;
-        currentValue = memo?.entity.has(trait) ?? false;
-        if (currentValue !== value) setValue(currentValue);
+        valueRef.current = memo?.entity.has(trait) ?? false;
     }
 
     useEffect(() => {
         if (!memo) {
-            setValue(false);
+            valueRef.current = false;
+            forceUpdate();
             return;
         }
 
-        const unsubscribe = memo.subscribe(setValue);
+        const unsubscribe = memo.subscribe((value) => {
+            valueRef.current = value;
+            forceUpdate();
+        });
+
         return () => unsubscribe();
     }, [memo]);
 
-    return currentValue;
+    return valueRef.current;
 }
 
 function createSubscriptions(target: Entity | World, trait: Trait, contextWorld: World) {

--- a/packages/react/src/hooks/use-query.ts
+++ b/packages/react/src/hooks/use-query.ts
@@ -1,57 +1,69 @@
 import { $internal, createQuery, type QueryParameter, type QueryResult } from '@koota/core';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
 import { useWorld } from '../world/use-world';
 
 export function useQuery<T extends QueryParameter[]>(...parameters: T): QueryResult<T> {
     const world = useWorld();
-    const initialQueryVersionRef = useRef(0);
-    // Used to track if we need to rerun effects internally.
-    const [version, setVersion] = useState(0);
+    const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
-    // This will rerun every render since parameters will always be a fresh
-    // array, but the return value will be stable.
-    const queryRef = useMemo(() => createQuery(...parameters), [parameters]);
-    // Registers the query with the world.
-    const [entities, setEntities] = useState<QueryResult<T>>(() => world.query(queryRef).sort());
+    const queryRef = useMemo(() => createQuery(...parameters), parameters);
+    const cacheRef = useRef<{ hash: string; version: number; result: QueryResult<T> } | null>(null);
 
-    initialQueryVersionRef.current = useMemo(() => {
-        // Using internals to get the query data.
-        const query = world[$internal].queriesHashMap.get(queryRef.hash)!;
-        return query.version;
-    }, [world, queryRef]);
+    // Compute result: uses cache if valid, otherwise recomputes
+    const getResult = (): QueryResult<T> => {
+        const query = world[$internal].queriesHashMap.get(queryRef.hash);
 
-    // Subscribe to changes.
-    useEffect(() => {
-        const unsubAdd = world.onQueryAdd(queryRef, () => {
-            setEntities(world.query(queryRef).sort());
-        });
-
-        const unsubRemove = world.onQueryRemove(queryRef, () => {
-            setEntities(world.query(queryRef).sort());
-        });
-
-        // Compare the initial version to the current version to
-        // see it the query has changed.
-        const query = world[$internal].queriesHashMap.get(queryRef.hash)!;
-        if (query.version !== initialQueryVersionRef.current) {
-            setEntities(world.query(queryRef).sort());
+        if (
+            query &&
+            cacheRef.current?.hash === queryRef.hash &&
+            cacheRef.current.version === query.version
+        ) {
+            return cacheRef.current.result;
         }
 
+        const result = world.query(queryRef).sort();
+        const registeredQuery = world[$internal].queriesHashMap.get(queryRef.hash)!;
+        cacheRef.current = { hash: queryRef.hash, version: registeredQuery.version, result };
+
+        return result;
+    };
+
+    const result = getResult();
+
+    useEffect(() => {
+        const update = () => forceUpdate();
+
+        let unsubAdd = () => {};
+        let unsubRemove = () => {};
+
+        const subscribe = () => {
+            unsubAdd = world.onQueryAdd(queryRef, update);
+            unsubRemove = world.onQueryRemove(queryRef, update);
+
+            // Check if query changed between render and effect
+            const query = world[$internal].queriesHashMap.get(queryRef.hash)!;
+            if (cacheRef.current && query.version !== cacheRef.current.version) {
+                update();
+            }
+        };
+
+        const handleReset = () => {
+            cacheRef.current = null;
+            unsubAdd();
+            unsubRemove();
+            subscribe();
+            update();
+        };
+
+        subscribe();
+        world[$internal].resetSubscriptions.add(handleReset);
+
         return () => {
+            world[$internal].resetSubscriptions.delete(handleReset);
             unsubAdd();
             unsubRemove();
         };
-    }, [world, queryRef, version]);
+    }, [world, queryRef]);
 
-    // Force reattaching event listeners when the world is reset.
-    useEffect(() => {
-        const handler = () => setVersion((v) => v + 1);
-        world[$internal].resetSubscriptions.add(handler);
-
-        return () => {
-            world[$internal].resetSubscriptions.delete(handler);
-        };
-    }, [world]);
-
-    return entities;
+    return result;
 }

--- a/packages/react/src/hooks/use-target.ts
+++ b/packages/react/src/hooks/use-target.ts
@@ -1,5 +1,5 @@
 import { $internal, type Entity, type Relation, type Trait, type World } from '@koota/core';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
 import { isWorld } from '../utils/is-world';
 import { useWorld } from '../world/use-world';
 
@@ -8,36 +8,38 @@ export function useTarget<T extends Trait>(
     relation: Relation<T>
 ): Entity | undefined {
     const contextWorld = useWorld();
+    const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
     const memo = useMemo(
         () => (target ? createSubscriptions(target, relation, contextWorld) : undefined),
         [target, relation, contextWorld]
     );
 
-    const [value, setValue] = useState<Entity | undefined>(() => {
-        return memo?.entity.targetFor(relation);
-    });
-
-    // Track memo changes and compute correct value for this render
+    const valueRef = useRef<Entity | undefined>(undefined);
     const memoRef = useRef(memo);
 
-    let currentValue = value;
+    // Update cached value when memo changes
     if (memoRef.current !== memo) {
         memoRef.current = memo;
-        currentValue = memo?.entity.targetFor(relation);
-        if (currentValue !== value) setValue(currentValue);
+        valueRef.current = memo?.entity.targetFor(relation);
     }
 
     useEffect(() => {
         if (!memo) {
-            setValue(undefined);
+            valueRef.current = undefined;
+            forceUpdate();
             return;
         }
-        const unsubscribe = memo.subscribe(setValue);
+
+        const unsubscribe = memo.subscribe((value) => {
+            valueRef.current = value;
+            forceUpdate();
+        });
+
         return () => unsubscribe();
     }, [memo]);
 
-    return currentValue;
+    return valueRef.current;
 }
 
 function createSubscriptions<T extends Trait>(

--- a/packages/react/tests/query.test.tsx
+++ b/packages/react/tests/query.test.tsx
@@ -1,4 +1,12 @@
-import { createWorld, type Entity, type QueryResult, trait, universe, type World } from '@koota/core';
+import {
+    createWorld,
+    type Entity,
+    type QueryResult,
+    relation,
+    trait,
+    universe,
+    type World,
+} from '@koota/core';
 import { render, renderHook } from '@testing-library/react';
 import { act, StrictMode } from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -212,5 +220,45 @@ describe('useQuery', () => {
         );
 
         expect(result.current.updateEach).toBeDefined();
+    });
+
+    it('should handle relation query when target entity changes', async () => {
+        const ChildOf = relation();
+        const Tag = trait();
+
+        const parent1 = world.spawn(Tag);
+        const parent2 = world.spawn(Tag);
+
+        // Two children of parent1
+        world.spawn(Tag, ChildOf(parent1));
+        world.spawn(Tag, ChildOf(parent1));
+        // One child of parent2
+        world.spawn(Tag, ChildOf(parent2));
+
+        let entities: QueryResult<[typeof Tag, ReturnType<typeof ChildOf>]> = null!;
+
+        function Test({ parent }: { parent: Entity }) {
+            entities = useQuery(Tag, ChildOf(parent));
+            return null;
+        }
+
+        const { rerender } = render(
+            <WorldProvider world={world}>
+                <Test parent={parent1} />
+            </WorldProvider>
+        );
+
+        expect(entities.length).toBe(2);
+
+        // Change parent - the query should update to reflect children of parent2
+        await act(async () => {
+            rerender(
+                <WorldProvider world={world}>
+                    <Test parent={parent2} />
+                </WorldProvider>
+            );
+        });
+
+        expect(entities.length).toBe(1);
     });
 });


### PR DESCRIPTION
It was possible than then the relation target in a useQuery changed, that there would be an initialization error. Ie, `useQuery(ChildOf(targetEntity))` where `targetEntity` changes between renders. The fix was applied to similar hooks to harden behavior in general.