### PR TITLE
refactor: Rewrite useStore API for paged stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,18 +629,28 @@ world.query(Position, Velocity, Mass)
 
 ### Modifying trait stores directly
 
-For performance-critical operations, you can modify trait stores directly using the `useStores` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. All stores are structure of arrays for performance purposes.
+For performance-critical operations, you can modify trait stores directly using the `useStores` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. Stores are paged internally, so `useStores` gives you the raw paged stores plus a layout describing which query entities live in which pages and offsets.
 
 ```js
-// Returns the SoA stores
-world.query(Position, Velocity).useStores(([position, velocity], entities) => {
-  // Write our own loop over the stores
-  for (let i = 0; i < entities.length; i++) {
-    // Get the entity ID to use as the array index
-    const eid = entities[i].id()
-    // Write to each array in the store
-    position.x[eid] += velocity.x[eid] * delta
-    position.y[eid] += velocity.y[eid] * delta
+// Returns the raw stores plus a page-grouped query layout
+world.query(Position, Velocity).useStores(([position, velocity], layout) => {
+  // Loop over all the pages
+  for (let p = 0; p < layout.pageCount; p++) {
+    const pageId = layout.pageIds[p] // Physical page in the paged stores
+    const start = layout.pageStarts[p] // First flat query index in this page
+    const end = start + layout.pageCounts[p] // One past the last flat query index
+
+    const posX = position.x[pageId]
+    const posY = position.y[pageId]
+    const velX = velocity.x[pageId]
+    const velY = velocity.y[pageId]
+
+    // For each entity in the page, updates its data
+    for (let i = start; i < end; i++) {
+      const o = layout.offsets[i] // Offset within the current page
+      posX[o] += velX[o] * delta
+      posY[o] += velY[o] * delta
+    }
   }
 })
 ```

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -11,18 +11,25 @@ Performance, safety and readability are all tradeoffs. The standard patterns are
 
 ## Modifying trait stores directly
 
-For performance-critical operations, you can modify trait stores directly using the `useStores` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. All stores are structure of arrays for performance purposes.
+For performance-critical operations, you can modify trait stores directly using the `useStores` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. Stores are paged internally, and `useStores` returns the raw stores plus a cached page-grouped layout so your loops can stay cache-friendly without manual page math.
 
 ```js
-// Returns the SoA stores
-world.query(Position, Velocity).useStores(([position, velocity], entities) => {
-  // Write our own loop over the stores
-  for (let i = 0; i < entities.length; i++) {
-    // Get the entity ID to use as the array index
-    const eid = entities[i].id()
-    // Write to each array in the store
-    position.x[eid] += velocity.x[eid] * delta
-    position.y[eid] += velocity.y[eid] * delta
+// Returns the raw stores plus a page-grouped query layout
+world.query(Position, Velocity).useStores(([position, velocity], layout) => {
+  for (let p = 0; p < layout.pageCount; p++) {
+    const pageId = layout.pageIds[p]
+    const start = layout.pageStarts[p]
+    const end = start + layout.pageCounts[p]
+    const posX = position.x[pageId]
+    const posY = position.y[pageId]
+    const velX = velocity.x[pageId]
+    const velY = velocity.y[pageId]
+
+    for (let i = start; i < end; i++) {
+      const o = layout.offsets[i]
+      posX[o] += velX[o] * delta
+      posY[o] += velY[o] * delta
+    }
   }
 })
 ```

--- a/examples/add-remove/src/view/systems/syncThreeObjects.ts
+++ b/examples/add-remove/src/view/systems/syncThreeObjects.ts
@@ -18,29 +18,45 @@ export const syncThreeObjects = ({ world }: { world: World }) => {
     const colors = particles.geometry.attributes.color.array;
     const sizes = particles.geometry.attributes.size.array;
 
-    entities.useStores(([position, circle, color]) => {
-        for (let i = 0; i < entities.length; i++) {
-            const eid = entities[i].id();
+    entities.useStores(([position, circle, color], layout) => {
+        const { pageCount, pageIds, pageStarts, pageCounts, offsets, entities } = layout;
 
-            // Update positions
-            positions[eid * 3] = position.x[eid];
-            positions[eid * 3 + 1] = position.y[eid];
-            positions[eid * 3 + 2] = position.z[eid];
+        for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+            const pageId = pageIds[pageIndex];
+            const start = pageStarts[pageIndex];
+            const end = start + pageCounts[pageIndex];
+            const posX = position.x[pageId];
+            const posY = position.y[pageId];
+            const posZ = position.z[pageId];
+            const radius = circle.radius[pageId];
+            const colorR = color.r[pageId];
+            const colorG = color.g[pageId];
+            const colorB = color.b[pageId];
 
-            // Update sizes
-            sizes[eid] = circle.radius[eid] * 0.3;
+            for (let i = start; i < end; i++) {
+                const eid = entities[i].id();
+                const offset = offsets[i];
 
-            // Update colors
-            const r = normalize(color.r[eid], 0, 255);
-            const g = normalize(color.g[eid], 0, 255);
-            const b = normalize(color.b[eid], 0, 255);
-            colors[eid * 3] = r;
-            colors[eid * 3 + 1] = g;
-            colors[eid * 3 + 2] = b;
+                // Update positions
+                positions[eid * 3] = posX[offset];
+                positions[eid * 3 + 1] = posY[offset];
+                positions[eid * 3 + 2] = posZ[offset];
+
+                // Update sizes
+                sizes[eid] = radius[offset] * 0.3;
+
+                // Update colors
+                const r = normalize(colorR[offset], 0, 255);
+                const g = normalize(colorG[offset], 0, 255);
+                const b = normalize(colorB[offset], 0, 255);
+                colors[eid * 3] = r;
+                colors[eid * 3 + 1] = g;
+                colors[eid * 3 + 2] = b;
+            }
         }
 
         for (let i = 0; i < removedEntities.length; i++) {
-            const eid = removedEntities[i];
+            const eid = removedEntities[i].id();
             sizes[eid] = 0;
         }
     });

--- a/examples/n-body/src/sim/systems/updateGravity.ts
+++ b/examples/n-body/src/sim/systems/updateGravity.ts
@@ -7,34 +7,67 @@ export const updateGravity = ({ world }: { world: World }) => {
     const bodies = world.query(...bodyTraits);
     const { delta } = world.get(Time)!;
 
-    bodies.useStores(([position, velocity, mass, _, acceleration], bodies) => {
-        for (let j = 0; j < bodies.length; j++) {
-            const currentId = bodies[j].id();
+    bodies.useStores(([position, velocity, mass, _, acceleration], layout) => {
+        const { pageCount, pageIds, pageStarts, pageCounts, offsets } = layout;
 
-            acceleration.x[currentId] = 0;
-            acceleration.y[currentId] = 0;
+        for (let currentPageIndex = 0; currentPageIndex < pageCount; currentPageIndex++) {
+            const currentPageId = pageIds[currentPageIndex];
+            const currentStart = pageStarts[currentPageIndex];
+            const currentEnd = currentStart + pageCounts[currentPageIndex];
+            const currentPosX = position.x[currentPageId];
+            const currentPosY = position.y[currentPageId];
+            const currentVelX = velocity.x[currentPageId];
+            const currentVelY = velocity.y[currentPageId];
+            const currentMass = mass.value[currentPageId];
+            const currentAccX = acceleration.x[currentPageId];
+            const currentAccY = acceleration.y[currentPageId];
 
-            for (let i = 0; i < bodies.length; i++) {
-                const targetId = bodies[i].id();
-                if (currentId === targetId) continue; // Skip self
+            for (let currentIndex = currentStart; currentIndex < currentEnd; currentIndex++) {
+                const currentOffset = offsets[currentIndex];
+                const currentX = currentPosX[currentOffset];
+                const currentY = currentPosY[currentOffset];
+                const bodyMass = +currentMass[currentOffset];
 
-                const dx = position.x[targetId] - position.x[currentId];
-                const dy = position.y[targetId] - position.y[currentId];
-                let distanceSquared = dx * dx + dy * dy;
+                currentAccX[currentOffset] = 0;
+                currentAccY[currentOffset] = 0;
 
-                if (distanceSquared < CONSTANTS.STICKY) distanceSquared = CONSTANTS.STICKY; // Apply stickiness
+                for (let targetPageIndex = 0; targetPageIndex < pageCount; targetPageIndex++) {
+                    const targetPageId = pageIds[targetPageIndex];
+                    const targetStart = pageStarts[targetPageIndex];
+                    const targetEnd = targetStart + pageCounts[targetPageIndex];
+                    const targetPosX = position.x[targetPageId];
+                    const targetPosY = position.y[targetPageId];
+                    const targetMass = mass.value[targetPageId];
 
-                const distance = Math.sqrt(distanceSquared);
-                const forceMagnitude =
-                    (+mass.value[currentId] * +mass.value[targetId]) / distanceSquared;
+                    for (let targetIndex = targetStart; targetIndex < targetEnd; targetIndex++) {
+                        const targetOffset = offsets[targetIndex];
 
-                acceleration.x[currentId] += (dx / distance) * forceMagnitude;
-                acceleration.y[currentId] += (dy / distance) * forceMagnitude;
+                        if (
+                            currentPageId === targetPageId &&
+                            currentOffset === targetOffset
+                        ) {
+                            continue;
+                        }
+
+                        const dx = targetPosX[targetOffset] - currentX;
+                        const dy = targetPosY[targetOffset] - currentY;
+                        let distanceSquared = dx * dx + dy * dy;
+
+                        if (distanceSquared < CONSTANTS.STICKY) distanceSquared = CONSTANTS.STICKY;
+
+                        const distance = Math.sqrt(distanceSquared);
+                        const forceMagnitude =
+                            (bodyMass * +targetMass[targetOffset]) / distanceSquared;
+
+                        currentAccX[currentOffset] += (dx / distance) * forceMagnitude;
+                        currentAccY[currentOffset] += (dy / distance) * forceMagnitude;
+                    }
+                }
+
+                // Apply computed force to entity's velocity, adjusting for its mass
+                currentVelX[currentOffset] += (currentAccX[currentOffset] * delta) / bodyMass;
+                currentVelY[currentOffset] += (currentAccY[currentOffset] * delta) / bodyMass;
             }
-
-            // Apply computed force to entity's velocity, adjusting for its mass
-            velocity.x[currentId] += (acceleration.x[currentId] * delta) / mass.value[currentId];
-            velocity.y[currentId] += (acceleration.y[currentId] * delta) / mass.value[currentId];
         }
     });
 };

--- a/examples/react-120/src/sim/systems/update-ball-collision.ts
+++ b/examples/react-120/src/sim/systems/update-ball-collision.ts
@@ -5,53 +5,80 @@ export function updateBallCollision(world: World) {
     const { delta } = world.get(Time)!;
     const invDelta = delta > 0 ? 1 / delta : 0;
 
-    world.query(Position, Velocity, Ball).useStores(([position, velocity, ball], entities) => {
-        for (let i = 0; i < entities.length; i++) {
-            const idA = entities[i].id();
+    world.query(Position, Velocity, Ball).useStores(([position, velocity, ball], layout) => {
+        const { pageCount, pageIds, pageStarts, pageCounts, offsets, entities } = layout;
 
-            const xA = position.x[idA];
-            const yA = position.y[idA];
-            const scaleA = entities[i].get(Scale)?.value ?? 1;
-            const radiusA = ball.radius[idA] * scaleA;
-            const massA = radiusA * radiusA * Math.PI;
+        for (let aPageIndex = 0; aPageIndex < pageCount; aPageIndex++) {
+            const aPageId = pageIds[aPageIndex];
+            const aStart = pageStarts[aPageIndex];
+            const aEnd = aStart + pageCounts[aPageIndex];
+            const aPosX = position.x[aPageId];
+            const aPosY = position.y[aPageId];
+            const aVelX = velocity.x[aPageId];
+            const aVelY = velocity.y[aPageId];
+            const aRadius = ball.radius[aPageId];
 
-            for (let j = i + 1; j < entities.length; j++) {
-                const indexB = entities[j].id();
+            for (let ai = aStart; ai < aEnd; ai++) {
+                const offsetA = offsets[ai];
+                const entityA = entities[ai];
 
-                const xB = position.x[indexB];
-                const xY = position.y[indexB];
-                const scaleB = entities[j].get(Scale)?.value ?? 1;
-                const radiusB = ball.radius[indexB] * scaleB;
+                const xA = aPosX[offsetA];
+                const yA = aPosY[offsetA];
+                const scaleA = entityA.get(Scale)?.value ?? 1;
+                const radiusA = aRadius[offsetA] * scaleA;
+                const massA = radiusA * radiusA * Math.PI;
 
-                const rsum = radiusA + radiusB;
-                const dx = xA - xB;
-                const dy = yA - xY;
+                for (let bPageIndex = aPageIndex; bPageIndex < pageCount; bPageIndex++) {
+                    const bPageId = pageIds[bPageIndex];
+                    const bPageStart = pageStarts[bPageIndex];
+                    const bEnd = bPageStart + pageCounts[bPageIndex];
+                    const bStart = bPageIndex === aPageIndex ? ai + 1 : bPageStart;
+                    const bPosX = position.x[bPageId];
+                    const bPosY = position.y[bPageId];
+                    const bVelX = velocity.x[bPageId];
+                    const bVelY = velocity.y[bPageId];
+                    const bRadius = ball.radius[bPageId];
 
-                // AABB early-out
-                if (dx > rsum || -dx > rsum || dy > rsum || -dy > rsum) continue;
+                    for (let bi = bStart; bi < bEnd; bi++) {
+                        const offsetB = offsets[bi];
+                        const entityB = entities[bi];
 
-                // Circle overlap check
-                const distSq = dx * dx + dy * dy;
-                if (distSq >= rsum * rsum) continue;
+                        const xB = bPosX[offsetB];
+                        const yB = bPosY[offsetB];
+                        const scaleB = entityB.get(Scale)?.value ?? 1;
+                        const radiusB = bRadius[offsetB] * scaleB;
 
-                // Penetration along the center line (mirrors reference scaling by radius sum)
-                const dist = Math.sqrt(distSq) || 1;
-                const penetration = dist - rsum; // negative
-                const invNorm = 1 / rsum;
-                const offX = dx * penetration * invNorm;
-                const offY = dy * penetration * invNorm;
+                        const rsum = radiusA + radiusB;
+                        const dx = xA - xB;
+                        const dy = yA - yB;
 
-                // Mass-based momentum distribution (πr²)
-                const massB = radiusB * radiusB * Math.PI;
-                const invTotal = 1 / (massA + massB);
-                const ratioA = massB * invTotal; // push A by proportion of B
-                const ratioB = massA * invTotal; // push B by proportion of A
+                        // AABB early-out
+                        if (dx > rsum || -dx > rsum || dy > rsum || -dy > rsum) continue;
 
-                // Convert position-like offsets to per-second velocity impulses
-                velocity.x[idA] -= offX * ratioA * invDelta;
-                velocity.y[idA] -= offY * ratioA * invDelta;
-                velocity.x[indexB] += offX * ratioB * invDelta;
-                velocity.y[indexB] += offY * ratioB * invDelta;
+                        // Circle overlap check
+                        const distSq = dx * dx + dy * dy;
+                        if (distSq >= rsum * rsum) continue;
+
+                        // Penetration along the center line (mirrors reference scaling by radius sum)
+                        const dist = Math.sqrt(distSq) || 1;
+                        const penetration = dist - rsum; // negative
+                        const invNorm = 1 / rsum;
+                        const offX = dx * penetration * invNorm;
+                        const offY = dy * penetration * invNorm;
+
+                        // Mass-based momentum distribution (πr²)
+                        const massB = radiusB * radiusB * Math.PI;
+                        const invTotal = 1 / (massA + massB);
+                        const ratioA = massB * invTotal; // push A by proportion of B
+                        const ratioB = massA * invTotal; // push B by proportion of A
+
+                        // Convert position-like offsets to per-second velocity impulses
+                        aVelX[offsetA] -= offX * ratioA * invDelta;
+                        aVelY[offsetA] -= offY * ratioA * invDelta;
+                        bVelX[offsetB] += offX * ratioB * invDelta;
+                        bVelY[offsetB] += offY * ratioB * invDelta;
+                    }
+                }
             }
         }
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export type {
     InstancesFromParameters,
     IsNotModifier,
     Modifier,
+    QueryLayout,
     Query,
     QueryModifier,
     QueryParameter,

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -14,6 +14,8 @@ import { setChanged } from './modifiers/changed';
 import type {
     InstancesFromParameters,
     QueryInstance,
+    QueryLayout,
+    QueryLayoutCache,
     QueryParameter,
     QueryResult,
     QueryResultOptions,
@@ -30,6 +32,7 @@ export function createQueryResult<T extends QueryParameter[]>(
     const stores: Store<any>[] = [];
 
     getQueryStores(params, traits, stores, ctx);
+    let usesCustomOrder = false;
 
     const results = Object.assign(entities, {
         readEach(
@@ -161,8 +164,11 @@ export function createQueryResult<T extends QueryParameter[]>(
             return results;
         },
 
-        useStores(callback: (stores: StoresFromParameters<T>, entities: readonly Entity[]) => void) {
-            callback(stores as unknown as StoresFromParameters<T>, entities);
+        useStores(callback: (stores: StoresFromParameters<T>, layout: QueryLayout) => void) {
+            const layout = usesCustomOrder
+                ? createQueryLayout(entities)
+                : getCachedQueryLayout(query, entities);
+            callback(stores as unknown as StoresFromParameters<T>, layout);
             return results;
         },
 
@@ -176,6 +182,7 @@ export function createQueryResult<T extends QueryParameter[]>(
         sort(
             callback: (a: Entity, b: Entity) => number = (a, b) => getEntityId(a) - getEntityId(b)
         ): QueryResult<T> {
+            usesCustomOrder = true;
             Array.prototype.sort.call(entities, callback);
             return results;
         },
@@ -268,11 +275,105 @@ export function createQueryResult<T extends QueryParameter[]>(
     }
 }
 
+type QueryPageBuilder = {
+    pageId: number;
+    offsets: number[];
+    entities: Entity[];
+};
+
+const EMPTY_LAYOUT_CACHE: QueryLayoutCache = {
+    version: -1,
+    pageCount: 0,
+    pageIds: new Uint32Array(0),
+    pageStarts: new Uint32Array(0),
+    pageCounts: new Uint16Array(0),
+    offsets: new Uint16Array(0),
+    entities: [],
+};
+
+function getCachedQueryLayout(query: QueryInstance, entities: readonly Entity[]): QueryLayout {
+    const cache = query.layoutCache;
+    if (cache && cache.version === query.version) return cache;
+
+    const next = createQueryLayout(entities, query.version);
+    query.layoutCache = next;
+    return next;
+}
+
+function createQueryLayout(
+    entities: readonly Entity[],
+    version = EMPTY_LAYOUT_CACHE.version
+): QueryLayoutCache {
+    if (entities.length === 0) return EMPTY_LAYOUT_CACHE;
+
+    const pagesById = new Map<number, QueryPageBuilder>();
+
+    for (let i = 0; i < entities.length; i++) {
+        const entity = entities[i];
+        const eid = getEntityId(entity);
+        const pageId = eid >>> 10;
+
+        let page = pagesById.get(pageId);
+        if (!page) {
+            page = {
+                pageId,
+                offsets: [],
+                entities: [],
+            };
+            pagesById.set(pageId, page);
+        }
+
+        page.offsets.push(eid & 1023);
+        page.entities.push(entity);
+    }
+
+    const orderedPages = Array.from(pagesById.values()).sort((a, b) => a.pageId - b.pageId);
+    const pageCount = orderedPages.length;
+    const pageIds = new Uint32Array(pageCount);
+    const pageStarts = new Uint32Array(pageCount);
+    const pageCounts = new Uint16Array(pageCount);
+
+    let flatIndex = 0;
+    for (let i = 0; i < pageCount; i++) {
+        const page = orderedPages[i];
+        pageIds[i] = page.pageId;
+        pageStarts[i] = flatIndex;
+        pageCounts[i] = page.offsets.length;
+        flatIndex += page.offsets.length;
+    }
+
+    const offsets = new Uint16Array(flatIndex);
+    const orderedEntities = new Array<Entity>(flatIndex);
+
+    let offsetIndex = 0;
+    for (let i = 0; i < pageCount; i++) {
+        const page = orderedPages[i];
+        for (let j = 0; j < page.offsets.length; j++) {
+            offsets[offsetIndex] = page.offsets[j];
+            orderedEntities[offsetIndex] = page.entities[j];
+            offsetIndex++;
+        }
+    }
+
+    return {
+        version,
+        pageCount,
+        pageIds,
+        pageStarts,
+        pageCounts,
+        offsets,
+        entities: orderedEntities,
+    };
+}
+
 export function createEmptyQueryResult(): QueryResult<QueryParameter[]> {
     const results = Object.assign([], {
         readEach: () => results,
         updateEach: () => results,
-        useStores: () => results,
+        useStores: (callback: any) => {
+            callback([], EMPTY_LAYOUT_CACHE);
+            return results;
+        },
         select: () => results,
         sort: () => results,
     }) as QueryResult<QueryParameter[]>;
@@ -295,7 +396,7 @@ const relationOnlyMethods = {
         return this;
     },
     useStores(this: QueryResult<any>, callback: any) {
-        callback([], this);
+        callback([], createQueryLayout(this as unknown as Entity[]));
         return this;
     },
     select(this: QueryResult<any>) {

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -192,6 +192,7 @@ export function createQueryInstance<T extends QueryParameter[]>(
         cleanup: [],
         addSubscriptions: new Set<QuerySubscriber>(),
         removeSubscriptions: new Set<QuerySubscriber>(),
+        layoutCache: null,
         relationFilters: [],
 
         run: (ctx: WorldContext, params: QueryParameter[]) => runQuery(ctx, query, params),

--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -23,6 +23,20 @@ export type QueryResultOptions = {
     changeDetection?: 'always' | 'auto' | 'never';
 };
 
+export type QueryLayout = {
+    pageCount: number;
+    pageIds: Uint32Array;
+    pageStarts: Uint32Array;
+    pageCounts: Uint16Array;
+    offsets: Uint16Array;
+    entities: readonly Entity[];
+};
+
+export type QueryLayoutCache = Omit<QueryLayout, 'entities'> & {
+    version: number;
+    entities: readonly Entity[];
+};
+
 export type QueryResult<T extends QueryParameter[] = QueryParameter[]> = readonly Entity[] & {
     readEach: (
         callback: (state: InstancesFromParameters<T>, entity: Entity, index: number) => void
@@ -32,7 +46,7 @@ export type QueryResult<T extends QueryParameter[] = QueryParameter[]> = readonl
         options?: QueryResultOptions
     ) => QueryResult<T>;
     useStores: (
-        callback: (stores: StoresFromParameters<T>, entities: readonly Entity[]) => void
+        callback: (stores: StoresFromParameters<T>, layout: QueryLayout) => void
     ) => QueryResult<T>;
     select<U extends QueryParameter[]>(...params: U): QueryResult<U>;
     sort(callback?: (a: Entity, b: Entity) => number): QueryResult<T>;
@@ -169,6 +183,7 @@ export type QueryInstance<T extends QueryParameter[] = QueryParameter[]> = {
     cleanup: QueryUnsubscriber[];
     addSubscriptions: Set<QuerySubscriber>;
     removeSubscriptions: Set<QuerySubscriber>;
+    layoutCache: QueryLayoutCache | null;
     /** Relation pairs for target-specific queries */
     relationFilters?: ResolvedRelationFilter[];
     run: (ctx: WorldContext, params: QueryParameter[]) => QueryResult<T>;

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -280,6 +280,41 @@ describe('Query', () => {
         expect(results[2]).toEqual({ x: 2, name: 'Entity2', index: 2 });
     });
 
+    it('useStores groups entities into query pages', () => {
+        const localWorld = createWorld();
+
+        // Pages are 1024 entities wide
+        for (let i = 0; i < 1026; i++) {
+            localWorld.spawn(Position({ x: i, y: i * 2 }));
+        }
+
+        const query = localWorld.query(Position);
+
+        query.useStores(([position], layout) => {
+            expect(layout.pageCount).toBe(2);
+
+            const firstEntityId = layout.entities[0].id();
+            const firstPageId = layout.pageIds[0];
+            const secondPageId = layout.pageIds[1];
+
+            expect(layout.pageCounts[0]).toBe(1023);
+            expect(layout.offsets[0]).toBe(firstEntityId & 1023);
+            expect(layout.entities[0].id()).toBe(firstEntityId);
+            expect(position.x[firstPageId][layout.offsets[1]]).toBe(1);
+
+            expect(layout.pageCounts[1]).toBe(3);
+            expect(Array.from(layout.offsets.slice(layout.pageStarts[1]))).toEqual([0, 1, 2]);
+            expect(layout.entities.slice(layout.pageStarts[1]).map((entity) => entity.id())).toEqual([
+                firstEntityId + 1023,
+                firstEntityId + 1024,
+                firstEntityId + 1025,
+            ]);
+            expect(position.x[secondPageId][layout.offsets[layout.pageStarts[1] + 2]]).toBe(1025);
+        });
+
+        localWorld.destroy();
+    });
+
     it('updateEach should return values in caller parameter order regardless of cache', () => {
         // Create entity with both traits
         world.spawn(Position({ x: 10, y: 20 }), Name({ name: 'test' }));

--- a/skills/koota/references/queries.md
+++ b/skills/koota/references/queries.md
@@ -233,14 +233,24 @@ world
 
 ## Direct store access
 
-For maximum performance, access SoA stores directly with `useStores`:
+For maximum performance, access the raw stores with a cached page-grouped layout. Stores are paged internally, so the layout tells you which query entities belong to which store page and offset:
 
 ```typescript
-world.query(Position, Velocity).useStores(([position, velocity], entities) => {
-  for (let i = 0; i < entities.length; i++) {
-    const eid = entities[i].id()
-    position.x[eid] += velocity.x[eid] * delta
-    position.y[eid] += velocity.y[eid] * delta
+world.query(Position, Velocity).useStores(([position, velocity], layout) => {
+  for (let p = 0; p < layout.pageCount; p++) {
+    const pageId = layout.pageIds[p] // Physical page in the paged stores
+    const start = layout.pageStarts[p] // First flat query index in this page
+    const end = start + layout.pageCounts[p] // One past the last flat query index
+    const posX = position.x[pageId]
+    const posY = position.y[pageId]
+    const velX = velocity.x[pageId]
+    const velY = velocity.y[pageId]
+
+    for (let i = start; i < end; i++) {
+      const o = layout.offsets[i] // Offset within the current page
+      posX[o] += velX[o] * delta
+      posY[o] += velY[o] * delta
+    }
   }
 })
 ```


### PR DESCRIPTION
The store layout changed to paged from a single flat sparse array so the `useStore` API had to update to accommodate. This makes it more complex, but is actually faster despite the extra loop since each page is guaranteed to be cache efficient. When people need that kind of escape hatch, there it is.

```js
// Returns the raw stores plus a page-grouped query layout
world.query(Position, Velocity).useStores(([position, velocity], layout) => {
  // Loop over all the pages
  for (let p = 0; p < layout.pageCount; p++) {
    const pageId = layout.pageIds[p] // Physical page in the paged stores
    const start = layout.pageStarts[p] // First flat query index in this page
    const end = start + layout.pageCounts[p] // One past the last flat query index

    const posX = position.x[pageId]
    const posY = position.y[pageId]
    const velX = velocity.x[pageId]
    const velY = velocity.y[pageId]

    // For each entity in the page, updates its data
    for (let i = start; i < end; i++) {
      const o = layout.offsets[i] // Offset within the current page
      posX[o] += velX[o] * delta
      posY[o] += velY[o] * delta
    }
  }
})
```