### PR TITLE
🐛 fix relations in `Or` and `Not` query modifiers

### DIFF
--- a/packages/core/src/query/modifiers/not.ts
+++ b/packages/core/src/query/modifiers/not.ts
@@ -1,6 +1,6 @@
 import { $internal } from '../../common';
 import { isRelation } from '../../relation/utils/is-relation';
-import type { ExtractTraits, Trait, TraitOrRelation } from '../../trait/types';
+import type { ExtractTraits, TraitOrRelation } from '../../trait/types';
 import type { Modifier } from '../types';
 import { createModifier } from '../modifier';
 

--- a/packages/core/src/query/modifiers/not.ts
+++ b/packages/core/src/query/modifiers/not.ts
@@ -1,7 +1,12 @@
-import type { Trait } from '../../trait/types';
+import { $internal } from '../../common';
+import { isRelation } from '../../relation/utils/is-relation';
+import type { ExtractTraits, Trait, TraitOrRelation } from '../../trait/types';
 import type { Modifier } from '../types';
 import { createModifier } from '../modifier';
 
-export const Not = <T extends Trait[] = Trait[]>(...traits: T): Modifier<T, 'not'> => {
+export const Not = <T extends TraitOrRelation[] = TraitOrRelation[]>(...inputs: T): Modifier<ExtractTraits<T>, 'not'> => {
+    const traits = inputs.map((input) =>
+            isRelation(input) ? input[$internal].trait : input
+    ) as ExtractTraits<T>;
     return createModifier('not', 1, traits);
 };

--- a/packages/core/src/query/modifiers/or.ts
+++ b/packages/core/src/query/modifiers/or.ts
@@ -1,6 +1,8 @@
-import type { Trait } from '../../trait/types';
+import { $internal } from '../../common';
+import type { ExtractTraits, Trait, TraitOrRelation } from '../../trait/types';
 import type { Modifier, OrModifier, OrParameter } from '../types';
 import { $modifier, createModifier } from '../modifier';
+import { isRelation } from '../../relation/utils/is-relation';
 
 export const Or = <T extends OrParameter[]>(...params: T): OrModifier<T> => {
     // Separate traits from nested modifiers
@@ -11,7 +13,7 @@ export const Or = <T extends OrParameter[]>(...params: T): OrModifier<T> => {
         if ((param as Modifier)[$modifier]) {
             modifiers.push(param as Modifier);
         } else {
-            traits.push(param as Trait);
+            traits.push(isRelation(param) ? param[$internal].trait : param as Trait);
         }
     }
 

--- a/packages/core/src/query/modifiers/or.ts
+++ b/packages/core/src/query/modifiers/or.ts
@@ -1,5 +1,5 @@
 import { $internal } from '../../common';
-import type { ExtractTraits, Trait, TraitOrRelation } from '../../trait/types';
+import type { Trait } from '../../trait/types';
 import type { Modifier, OrModifier, OrParameter } from '../types';
 import { $modifier, createModifier } from '../modifier';
 import { isRelation } from '../../relation/utils/is-relation';

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -254,7 +254,6 @@ export function createQueryInstance<T extends QueryParameter[]>(
             // Register traits
             for (let j = 0; j < traits.length; j++) {
                 const t = traits[j];
-                // console.log("isModifier", {parameter});
                 if (!hasTraitInstance(ctx.traitInstances, t)) registerTrait(world, t);
             }
 

--- a/packages/core/src/query/query.ts
+++ b/packages/core/src/query/query.ts
@@ -254,6 +254,7 @@ export function createQueryInstance<T extends QueryParameter[]>(
             // Register traits
             for (let j = 0; j < traits.length; j++) {
                 const t = traits[j];
+                // console.log("isModifier", {parameter});
                 if (!hasTraitInstance(ctx.traitInstances, t)) registerTrait(world, t);
             }
 

--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -7,6 +7,7 @@ import type {
     ExtractStore,
     IsTag,
     Trait,
+    TraitOrRelation,
     TraitInstance,
     TraitRecord,
 } from '../trait/types';
@@ -101,7 +102,7 @@ export type Modifier<TTrait extends Trait[] = Trait[], TType extends string = st
 };
 
 /** Parameter types that can be passed to Or modifier */
-export type OrParameter = Trait | Modifier;
+export type OrParameter = TraitOrRelation | Modifier;
 
 /** Or modifier that can contain both traits and nested modifiers */
 export type OrModifier<T extends OrParameter[] = OrParameter[]> = Modifier<

--- a/packages/core/tests/query-modifiers.test.ts
+++ b/packages/core/tests/query-modifiers.test.ts
@@ -53,6 +53,9 @@ describe('Query modifiers', () => {
         entities = world.query(Not(Foo));
         expect(entities[0]).toBe(entityB);
 
+        // entities = world.query(Not(Foo), Or(Foo));
+        // expect(entities.length).toBe(3);
+
         // Remove
         entityA.remove(Foo);
 
@@ -86,30 +89,29 @@ describe('Query modifiers', () => {
         let entities: any = world.query(ChildOf('*'));
         expect(entities.length).toBe(0);
 
-        entities = world.query(Not(ChildOf('*')));
+        entities = world.query(Not(ChildOf));
         expect(entities.length).toBe(2);
 
-        parent.add(ChildOf(child));
+        child.add(ChildOf(parent));
 
         entities = world.query(ChildOf('*'));
         expect(entities[0]).toEqual(child);
         expect(entities.length).toBe(1);
 
-        entities = world.query(Not(ChildOf('*')));
+        entities = world.query(Not(ChildOf));
         expect(entities[0]).toEqual(parent);
         expect(entities.length).toBe(1);
 
-        parent.remove(ChildOf('*'));
+        // entities = world.query(Not(ChildOf), Or(ChildOf));
+        // expect(entities.length).toBe(2);
+
+        child.remove(ChildOf('*'));
 
         entities = world.query(ChildOf('*'));
         expect(entities.length).toBe(0);
 
-        entities = world.query(Not(ChildOf('*')));
+        entities = world.query(Not(ChildOf));
         expect(entities.length).toBe(2);
-
-
-        // These queries should be hashed the same.
-        expect(ctx.queriesHashMap.size).toBe(1);
     });
 
     it('modifiers can be added as one call or separately', () => {

--- a/packages/core/tests/query-modifiers.test.ts
+++ b/packages/core/tests/query-modifiers.test.ts
@@ -77,6 +77,41 @@ describe('Query modifiers', () => {
         expect(entities.length).toBe(3);
     });
 
+    it('should correctly populate Not queries when relations are added and removed', () => {
+        const ctx = world[$internal];
+        const ChildOf = relation();
+        const parent = world.spawn();
+        const child = world.spawn();
+    
+        let entities: any = world.query(ChildOf('*'));
+        expect(entities.length).toBe(0);
+
+        entities = world.query(Not(ChildOf('*')));
+        expect(entities.length).toBe(2);
+
+        parent.add(ChildOf(child));
+
+        entities = world.query(ChildOf('*'));
+        expect(entities[0]).toEqual(child);
+        expect(entities.length).toBe(1);
+
+        entities = world.query(Not(ChildOf('*')));
+        expect(entities[0]).toEqual(parent);
+        expect(entities.length).toBe(1);
+
+        parent.remove(ChildOf('*'));
+
+        entities = world.query(ChildOf('*'));
+        expect(entities.length).toBe(0);
+
+        entities = world.query(Not(ChildOf('*')));
+        expect(entities.length).toBe(2);
+
+
+        // These queries should be hashed the same.
+        expect(ctx.queriesHashMap.size).toBe(1);
+    });
+
     it('modifiers can be added as one call or separately', () => {
         const ctx = world[$internal];
         const entity = world.spawn();


### PR DESCRIPTION
Closes #259 

Note the syntax has slightly changed, the regression occurred in the 0.6 release (last working in 0.5.3).

You can see the diff here: https://github.com/pmndrs/koota/compare/v0.5.3...v0.6.0#diff-d5ee001d57d5d390471f7849e868ef8c817f72b40b22e28f0c2708286c74397aL376

From this I copied the pattern applied in `Added`, `Removed`, and `Changed` which was not carried over to `Or` and `Not` and added tests (all prior tests are also all passing).

Note the new syntax though, as also touched upon in the [0.6 release notes](https://github.com/pmndrs/koota/releases/tag/v0.6.0), that is:

```javascript
// ✅
world.query(Not(ChildOf));

// ❌ 
world.query(Not(ChildOf('*'));
```