### PR TITLE
docs: fix 'a changed has occured' -> 'a change has occurred' in change detection description

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ world
   .updateEach(([position, velocity]) => {}, { changeDetection: 'always' })
 ```
 
-Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a changed has occured.
+Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a change has occurred.
 
 ```js
 // ❌ This change will not be detected since the array is mutated and will pass the comparison

--- a/docs/advanced/change-detection.md
+++ b/docs/advanced/change-detection.md
@@ -18,7 +18,7 @@ world
   .updateEach(([position, velocity]) => {}, { changeDetection: 'always' })
 ```
 
-Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a changed has occured.
+Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a change has occurred.
 
 ```js
 // ❌ This change will not be detected since the array is mutated and will pass the comparison

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -563,7 +563,7 @@ world
   .updateEach(([position, velocity]) => {}, { changeDetection: 'always' })
 ```
 
-Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a changed has occured.
+Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a change has occurred.
 
 ```js
 // ❌ This change will not be detected since the array is mutated and will pass the comparison


### PR DESCRIPTION
Fix a grammar + typo in the change detection description across 3 docs:

- `docs/advanced/change-detection.md`
- `README.md` (main)
- `packages/publish/README.md`

Original: "manually flag that a changed has occured"
Fixed to: "manually flag that a change has occurred" (corrects both the typo and the subject-verb agreement).