### PR TITLE
Build the docs with pmndrs/docs@v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     if: github.ref == 'refs/heads/main'
-    uses: pmndrs/docs/.github/workflows/build.yml@v2
+    uses: pmndrs/docs/.github/workflows/build.yml@v4
     with:
       mdx: 'docs'
       libname: 'Koota'

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ world
   .updateEach(([position, velocity]) => {}, { changeDetection: 'always' })
 ```
 
-Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a changed has occured.
+Change detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a change has occurred.
 
 ```js
 // ❌ This change will not be detected since the array is mutated and will pass the comparison

--- a/docs/advanced/change-detection.md
+++ b/docs/advanced/change-detection.md
@@ -18,7 +18,7 @@ world
   .updateEach(([position, velocity]) => {}, { changeDetection: 'always' })
 ```
 
-Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a changed has occured.
+Change detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a change has occurred.
 
 ```js
 // ❌ This change will not be detected since the array is mutated and will pass the comparison

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -579,7 +579,7 @@ world
   .updateEach(([position, velocity]) => {}, { changeDetection: 'always' })
 ```
 
-Changed detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a changed has occured.
+Change detection shallowly compares the scalar values just like React. This means objects and arrays will only be detected as changed if a new object or array is committed to the store. While immutable state is a great design pattern, it creates memory pressure and reduces performance so instead you can mutate and manually flag that a change has occurred.
 
 ```js
 // ❌ This change will not be detected since the array is mutated and will pass the comparison


### PR DESCRIPTION
One line: the reusable workflow moves from `@v3`/`@v2` to `@v4`.

[pmndrs/docs v4](https://github.com/pmndrs/docs/releases/tag/v4.0.0) drops the Docker image. The workflow now builds through `npx @pmndrs/docs@latest` instead of `docker run ghcr.io/pmndrs/docs`.

Nothing else changes for this repository: the same inputs, the same environment variables, the same GitHub Pages artifact. The only removed input is `docker_tag`, which this workflow never passed.

The old tag stays where it is, so this repository keeps building on the Docker path until this merges.

> [!NOTE]
> These workflows only trigger on a push to the default branch, so this pull request runs no build of its own — the first real run happens after the merge.
