### PR TITLE
Update benchmarks for correctness

### DIFF
--- a/benches/change-detection/change-detection.bench.ts
+++ b/benches/change-detection/change-detection.bench.ts
@@ -1,4 +1,4 @@
-import { bench, group } from '@pmndrs/labs';
+import { assert, bench, group } from '@pmndrs/labs';
 import { createChanged, createWorld, trait, type Entity } from 'koota';
 
 const Position = trait({ x: 0, y: 0, z: 0 });
@@ -16,14 +16,16 @@ group('change detection 50k @change @query', () => {
       world.query(Changed(Position));
 
       const step = Math.floor(50_000 / changeCount);
-      yield () => {
+      const result = yield () => {
         for (let i = 0; i < changeCount; i++) {
           entities[i * step].set(Position, { x: i, y: i, z: i });
         }
-        world.query(Changed(Position));
+        return world.query(Changed(Position));
       };
 
       world.destroy();
-    }).gc('inner');
+      assert.equal(result.length, changeCount);
+      return result.length;
+    });
   }
 });

--- a/benches/entity-operations/entity-operations.bench.ts
+++ b/benches/entity-operations/entity-operations.bench.ts
@@ -14,11 +14,12 @@ group('spawn throughput 10k @entity', () => {
           world.spawn();
         }
       },
+      snapshot: () => world.entities.length,
       after: () => world.reset(),
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 
   bench('spawn with 1 trait', function* () {
     const world = createWorld();
@@ -29,11 +30,12 @@ group('spawn throughput 10k @entity', () => {
           world.spawn(Position);
         }
       },
+      snapshot: () => world.query(Position).length,
       after: () => world.reset(),
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 });
 
 group('entity.has dispatch 10k @entity', () => {
@@ -44,14 +46,17 @@ group('entity.has dispatch 10k @entity', () => {
       entities.push(world.spawn(Position));
     }
 
-    yield () => {
+    const result = yield () => {
+      let matches = 0;
       for (let i = 0; i < entities.length; i++) {
-        entities[i].has(Position);
+        if (entities[i].has(Position)) matches++;
       }
+      return matches;
     };
 
     world.destroy();
-  }).gc('inner');
+    return result;
+  });
 
   bench('entity.has (false)', function* () {
     const world = createWorld();
@@ -60,14 +65,17 @@ group('entity.has dispatch 10k @entity', () => {
       entities.push(world.spawn(Position));
     }
 
-    yield () => {
+    const result = yield () => {
+      let matches = 0;
       for (let i = 0; i < entities.length; i++) {
-        entities[i].has(Velocity);
+        if (entities[i].has(Velocity)) matches++;
       }
+      return matches;
     };
 
     world.destroy();
-  }).gc('inner');
+    return result;
+  });
 });
 
 group('entity.destroy 10k @entity', () => {
@@ -85,11 +93,12 @@ group('entity.destroy 10k @entity', () => {
           entities[i].destroy();
         }
       },
+      snapshot: () => entities.filter((entity) => world.has(entity)).length,
       after: spawn,
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 
   bench('destroy entities with 3 traits', function* () {
     const world = createWorld();
@@ -106,11 +115,12 @@ group('entity.destroy 10k @entity', () => {
           entities[i].destroy();
         }
       },
+      snapshot: () => entities.filter((entity) => world.has(entity)).length,
       after: spawn,
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 });
 
 group('entity get set 10k @entity', () => {
@@ -118,17 +128,20 @@ group('entity get set 10k @entity', () => {
     const world = createWorld();
     const entities: Entity[] = [];
     for (let i = 0; i < 10_000; i++) {
-      entities.push(world.spawn(Position));
+      entities.push(world.spawn(Position({ x: i })));
     }
 
-    yield () => {
+    const result = yield () => {
+      let sum = 0;
       for (let i = 0; i < entities.length; i++) {
-        entities[i].get(Position);
+        sum += entities[i].get(Position)!.x;
       }
+      return sum;
     };
 
     world.destroy();
-  }).gc('inner');
+    return result;
+  });
 
   bench('entity.set', function* () {
     const world = createWorld();
@@ -137,12 +150,15 @@ group('entity get set 10k @entity', () => {
       entities.push(world.spawn(Position));
     }
 
-    yield () => {
-      for (let i = 0; i < entities.length; i++) {
-        entities[i].set(Position, { x: i, y: i, z: i });
-      }
+    yield {
+      bench: () => {
+        for (let i = 0; i < entities.length; i++) {
+          entities[i].set(Position, { x: i, y: i, z: i });
+        }
+      },
+      snapshot: () => entities[entities.length - 1].get(Position),
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 });

--- a/benches/package.json
+++ b/benches/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.1",
   "type": "module",
   "dependencies": {
-    "@pmndrs/labs": "^0.6.0",
+    "@pmndrs/labs": "^0.9.0",
     "directed": "catalog:",
-    "koota": "workspace:*"
+    "koota": "workspace:*",
+    "math": "1.0.0-canary-37519dcd-20260903"
   },
   "devDependencies": {
     "@config/typescript": "workspace:*"

--- a/benches/query-performance/query-hash.bench.ts
+++ b/benches/query-performance/query-hash.bench.ts
@@ -29,21 +29,21 @@ const targetFilter: QueryParameter[] = [ChildOf(IsPlayer, IsActive), Position];
 group('query hash @query @hash', () => {
   bench('3 traits', function* () {
     yield () => createQueryHash(simple);
-  }).gc('inner');
+  });
 
   bench('modifiers', function* () {
     yield () => createQueryHash(withModifiers);
-  }).gc('inner');
+  });
 
   bench('relation + modifiers', function* () {
     yield () => createQueryHash(withRelation);
-  }).gc('inner');
+  });
 
   bench('dense mixed (7 params)', function* () {
     yield () => createQueryHash(dense);
-  }).gc('inner');
+  });
 
   bench('relation target filter', function* () {
     yield () => createQueryHash(targetFilter);
-  }).gc('inner');
+  });
 });

--- a/benches/query-performance/query-performance.bench.ts
+++ b/benches/query-performance/query-performance.bench.ts
@@ -16,12 +16,11 @@ group('query selectivity 50k @query', () => {
     const world = createWorld();
     for (let i = 0; i < 50_000; i++) world.spawn(Velocity);
 
-    yield () => {
-      world.query(Velocity);
-    };
+    const result = yield () => world.query(Velocity);
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
   bench('1 trait, ~1% match', function* () {
     const world = createWorld();
     for (let i = 0; i < 50_000; i++) {
@@ -30,12 +29,11 @@ group('query selectivity 50k @query', () => {
       } else world.spawn();
     }
 
-    yield () => {
-      world.query(Velocity);
-    };
+    const result = yield () => world.query(Velocity);
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
   bench('1 trait, ~0.1% match', function* () {
     const world = createWorld();
     for (let i = 0; i < 50_000; i++) {
@@ -44,12 +42,11 @@ group('query selectivity 50k @query', () => {
       } else world.spawn();
     }
 
-    yield () => {
-      world.query(Velocity);
-    };
+    const result = yield () => world.query(Velocity);
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 });
 
 group('n-way intersection 100k @query', () => {
@@ -70,59 +67,53 @@ group('n-way intersection 100k @query', () => {
 
   bench('1 trait, 100% match', function* () {
     const world = buildNWay();
-    yield () => {
-      world.query(Position);
-    };
+    const result = yield () => world.query(Position);
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('2 traits, 50% match', function* () {
     const world = buildNWay();
-    yield () => {
-      world.query(Position, Velocity);
-    };
+    const result = yield () => world.query(Position, Velocity);
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('3 traits, ~16% match)', function* () {
     const world = buildNWay();
-    yield () => {
-      world.query(Position, Velocity, Health);
-    };
+    const result = yield () => world.query(Position, Velocity, Health);
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('4 traits, ~3.3% match)', function* () {
     const world = buildNWay();
-    yield () => {
-      world.query(Position, Velocity, Health, HasRender);
-    };
+    const result = yield () => world.query(Position, Velocity, Health, HasRender);
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('5 traits, ~0.476% match)', function* () {
     const world = buildNWay();
-    yield () => {
-      world.query(Position, Velocity, Health, HasRender, HasPhysics);
-    };
+    const result = yield () => world.query(Position, Velocity, Health, HasRender, HasPhysics);
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('6 traits, ~0.043% match', function* () {
     const world = buildNWay();
-    yield () => {
-      world.query(Position, Velocity, Health, HasRender, HasPhysics, HasAI);
-    };
+    const result = yield () => world.query(Position, Velocity, Health, HasRender, HasPhysics, HasAI);
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('7 traits, ~0.003% match', function* () {
     const world = buildNWay();
-    yield () => {
+    const result = yield () =>
       world.query(Position, Velocity, Health, HasRender, HasPhysics, HasAI, HasCollider);
-    };
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 });
 
 group('not exclusion 50k @query', () => {
@@ -134,12 +125,11 @@ group('not exclusion 50k @query', () => {
       } else world.spawn(Position);
     }
 
-    yield () => {
-      world.query(Position, Not(IsStatic));
-    };
+    const result = yield () => world.query(Position, Not(IsStatic));
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('2 traits, 50% entities excluded', function* () {
     const world = createWorld();
@@ -149,12 +139,11 @@ group('not exclusion 50k @query', () => {
       } else world.spawn(Position);
     }
 
-    yield () => {
-      world.query(Position, Not(IsStatic));
-    };
+    const result = yield () => world.query(Position, Not(IsStatic));
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 });
 
 group('query throughput 50k @query', () => {
@@ -168,12 +157,11 @@ group('query throughput 50k @query', () => {
     }
     world.query(Position, Velocity);
 
-    yield () => {
-      world.query(Position, Velocity);
-    };
+    const result = yield () => world.query(Position, Velocity);
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('3 traits, query 3 - 10% match', function* () {
     const world = createWorld();
@@ -185,15 +173,14 @@ group('query throughput 50k @query', () => {
     }
     world.query(Position, Velocity, Health);
 
-    yield () => {
-      world.query(Position, Velocity, Health);
-    };
+    const result = yield () => world.query(Position, Velocity, Health);
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 });
 
-group('query maintenance 10k @query', () => {
+group('query maintenance 10k @query @maintenance', () => {
   const buildWithQueries = () => {
     const world = createWorld();
     const traitSubsets = [
@@ -224,13 +211,21 @@ group('query maintenance 10k @query', () => {
 
   bench('spawn when 20 queries active', function* () {
     const world = buildWithQueries();
-    yield () => {
-      for (let i = 0; i < 10_000; i++) {
-        world.spawn(Position, Velocity, Health);
-      }
+    yield {
+      bench: () => {
+        for (let i = 0; i < 10_000; i++) {
+          world.spawn(Position, Velocity, Health);
+        }
+      },
+      snapshot: () => world.query(Position, Velocity, Health).length,
+      after: () => {
+        for (const entity of world.query(Position)) entity.destroy();
+        // Commit removals while the world is empty.
+        world.query(Position);
+      },
     };
     world.destroy();
-  }).gc('inner');
+  });
 
   bench('add trait when 20 queries active', function* () {
     const world = buildWithQueries();
@@ -239,14 +234,22 @@ group('query maintenance 10k @query', () => {
       entities.push(world.spawn(Position, Velocity));
     }
 
-    yield () => {
-      for (let i = 0; i < entities.length; i++) {
-        entities[i].add(HasRender);
-      }
+    yield {
+      bench: () => {
+        for (let i = 0; i < entities.length; i++) {
+          entities[i].add(HasRender);
+        }
+      },
+      snapshot: () => world.query(Position, HasRender).length,
+      after: () => {
+        for (const entity of entities) entity.remove(HasRender);
+        // Commit removals before the next add.
+        world.query(HasRender);
+      },
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 
   bench('remove trait when 20 queries active', function* () {
     const world = buildWithQueries();
@@ -255,12 +258,20 @@ group('query maintenance 10k @query', () => {
       entities.push(world.spawn(Position, Velocity, Health, HasRender));
     }
 
-    yield () => {
-      for (let i = 0; i < entities.length; i++) {
-        entities[i].remove(Velocity);
-      }
+    yield {
+      bench: () => {
+        for (let i = 0; i < entities.length; i++) {
+          entities[i].remove(Velocity);
+        }
+      },
+      snapshot: () => world.query(Position, Velocity).length,
+      after: () => {
+        // Commit removals before restoring Velocity.
+        world.query(Velocity);
+        for (const entity of entities) entity.add(Velocity);
+      },
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 });

--- a/benches/relation-churn/relation-churn.bench.ts
+++ b/benches/relation-churn/relation-churn.bench.ts
@@ -7,5 +7,5 @@ group('relation churn @relation', () => {
   init({ world });
   bench(() => {
     schedule.run({ world });
-  }).gc('inner');
+  });
 });

--- a/benches/relation-churn/systems/init.ts
+++ b/benches/relation-churn/systems/init.ts
@@ -1,12 +1,13 @@
 import type { Entity, World } from 'koota';
+import { mulberry32 } from 'math/random';
 import { CONFIG } from '../config';
 import { Position, Velocity } from '../traits';
 
 export const allEntities: Entity[] = [];
 
-const randomRange = (min: number, max: number) => Math.random() * (max - min) + min;
-
 export const init = ({ world }: { world: World }) => {
+  const rng = mulberry32.create(42);
+  const randomRange = (min: number, max: number) => mulberry32.sample(rng) * (max - min) + min;
   const { entityCount } = CONFIG;
   const spread = 500;
 

--- a/benches/relation-performance/relation-performance.bench.ts
+++ b/benches/relation-performance/relation-performance.bench.ts
@@ -15,12 +15,11 @@ group('relation queries 10k @relation', () => {
       world.spawn(Position, ChildOf(parent));
     }
 
-    yield () => {
-      world.query(ChildOf(parent));
-    };
+    const result = yield () => world.query(ChildOf(parent));
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('100 parents, ChildOf(*)', function* () {
     const world = createWorld();
@@ -32,12 +31,11 @@ group('relation queries 10k @relation', () => {
       world.spawn(Position, ChildOf(parents[i % 100]));
     }
 
-    yield () => {
-      world.query(ChildOf('*'));
-    };
+    const result = yield () => world.query(ChildOf('*'));
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 });
 
 group('many targets single relation 10k @relation', () => {
@@ -54,12 +52,11 @@ group('many targets single relation 10k @relation', () => {
       }
 
       const queryTarget = targets[0];
-      yield () => {
-        world.query(Rel(queryTarget));
-      };
+      const result = yield () => world.query(Rel(queryTarget));
 
       world.destroy();
-    }).gc('inner');
+      return result.length;
+    });
   }
 });
 
@@ -84,12 +81,11 @@ group('many targets multiple relations 5k @relation', () => {
     }
 
     const queryTarget = targets[0];
-    yield () => {
-      world.query(RelA(queryTarget));
-    };
+    const result = yield () => world.query(RelA(queryTarget));
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('5 rels, 200 targets, query wildcard*', function* () {
     const world = createWorld();
@@ -103,12 +99,11 @@ group('many targets multiple relations 5k @relation', () => {
       world.spawn(Position, rel(target));
     }
 
-    yield () => {
-      world.query(RelA('*'));
-    };
+    const result = yield () => world.query(RelA('*'));
 
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 });
 
 group('relation target filters 10k @relation @query', () => {
@@ -134,49 +129,47 @@ group('relation target filters 10k @relation @query', () => {
 
   bench('100 parents, query ChildOf(parent)', function* () {
     const { world, parents } = buildWorld();
-    yield () => {
-      world.query(ChildOf(parents[0]));
-    };
+    const result = yield () => world.query(ChildOf(parents[0]));
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('100 parents, query ChildOf(IsPlayer)', function* () {
     const { world } = buildWorld();
-    yield () => {
-      world.query(ChildOf(IsPlayer));
-    };
+    const result = yield () => world.query(ChildOf(IsPlayer));
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('100 parents, manual ChildOf(*) filter IsPlayer', function* () {
     const { world } = buildWorld();
-    yield () => {
+    const result = yield () =>
       world.query(ChildOf('*')).filter((child) => child.targetFor(ChildOf)?.has(IsPlayer));
-    };
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('100 parents, query ChildOf(IsPlayer, IsActive)', function* () {
     const { world } = buildWorld();
-    yield () => {
-      world.query(ChildOf(IsPlayer, IsActive));
-    };
+    const result = yield () => world.query(ChildOf(IsPlayer, IsActive));
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 
   bench('100 parents, manual ChildOf(*) filter IsPlayer+IsActive', function* () {
     const { world } = buildWorld();
-    yield () => {
-      world.query(ChildOf('*')).filter((child) => {
+    const result = yield () => {
+      return world.query(ChildOf('*')).filter((child) => {
         const parent = child.targetFor(ChildOf);
         return parent?.has(IsPlayer) && parent?.has(IsActive);
       });
     };
     world.destroy();
-  }).gc('inner');
+    return result.length;
+  });
 });
 
-group('relation target filter maintenance 2k @relation @query', () => {
+group('relation target filter maintenance 2k @relation @query @toggle', () => {
   const ChildOf = relation();
 
   bench('toggle parents with ChildOf(IsPlayer) active', function* () {
@@ -194,15 +187,25 @@ group('relation target filter maintenance 2k @relation @query', () => {
 
     world.query(ChildOf(IsPlayer));
 
-    let enabled = false;
-    yield () => {
-      enabled = !enabled;
-      for (let i = 0; i < parents.length; i++) {
-        if ((i % 2 === 0) === enabled) parents[i].add(IsPlayer);
-        else parents[i].remove(IsPlayer);
-      }
+    let enabled = true;
+    yield {
+      bench: () => {
+        enabled = !enabled;
+        for (let i = 0; i < parents.length; i++) {
+          if ((i % 2 === 0) === enabled) parents[i].add(IsPlayer);
+          else parents[i].remove(IsPlayer);
+        }
+      },
+      snapshot: () => {
+        const matches = world.query(ChildOf(IsPlayer));
+        return [
+          matches.length,
+          matches.some((child) => child.targetFor(ChildOf) === parents[0]),
+          matches.some((child) => child.targetFor(ChildOf) === parents[1]),
+        ];
+      },
     };
 
     world.destroy();
-  }).gc('inner');
+  });
 });

--- a/benches/scene-graph-propagation/create-scene-graph-bench.ts
+++ b/benches/scene-graph-propagation/create-scene-graph-bench.ts
@@ -2,14 +2,8 @@ import { createChanged, createWorld, ordered, relation, trait, type Entity, type
 import { CONFIG } from './config.ts';
 
 /**
- * Builds a large synthetic scene graph and benchmarks the common propagation pattern:
- * dirty a fixed subset of nodes, walk upward to collect ancestor state, then push
- * updated totals downward through each dirty node's descendants.
- *
- * To keep runs comparable, the dirty system precomputes deterministic batches whose
- * estimated traversal cost is balanced by depth and subtree size. That preserves the
- * same mixed leaf/group propagation case without the large per-iteration swings that
- * come from dirtying entities in raw creation order.
+ * Dirties a mix of leaves and groups, then propagates ancestor totals to descendants.
+ * Fixed batches balance estimated traversal cost by depth and subtree size.
  */
 export type SceneGraphVariant = 'child-of-exclusive' | 'child-of-not-exclusive' | 'ordered-relation';
 
@@ -17,15 +11,8 @@ export type SceneGraphContext = {
   world: World;
   dirty: (ctx: { world: World }) => void;
   propagate: (ctx: { world: World }) => void;
+  snapshot: () => number;
 };
-
-type SceneGraphBuild = {
-  allEntities: Entity[];
-  depthByEntityId: number[];
-  subtreeSizeByEntityId: number[];
-};
-
-const deterministicValue = (index: number) => (index * 37) % 65;
 
 function createTraits(variant: SceneGraphVariant) {
   const ChildOf = variant === 'child-of-not-exclusive' ? relation() : relation({ exclusive: true });
@@ -40,101 +27,68 @@ function createTraits(variant: SceneGraphVariant) {
 
 type Traits = ReturnType<typeof createTraits>;
 
-function analyzeGraph(root: Entity, childrenByEntityId: Entity[][]) {
-  const depthByEntityId: number[] = [];
-  const subtreeSizeByEntityId: number[] = [];
-
-  const visit = (entity: Entity, depth: number): number => {
-    depthByEntityId[entity.id()] = depth;
-
-    let subtreeSize = 1;
-    const children = childrenByEntityId[entity.id()];
-    if (children) {
-      for (let i = 0; i < children.length; i++) {
-        subtreeSize += visit(children[i], depth + 1);
-      }
-    }
-
-    subtreeSizeByEntityId[entity.id()] = subtreeSize;
-    return subtreeSize;
-  };
-
-  visit(root, 0);
-
-  return { depthByEntityId, subtreeSizeByEntityId };
-}
-
-function buildGraph(world: World, traits: Traits): SceneGraphBuild {
+function buildGraph(world: World, traits: Traits) {
   const { ChildOf, OrderedChildren, IsGroup, IsObject, Value, TotalValue } = traits;
   const { targetEntityCount, bottomLeafFraction, groupChildrenCycle, objectChildrenCycle } = CONFIG;
-  const cap = targetEntityCount;
   const allEntities: Entity[] = [];
-  const childrenByEntityId: Entity[][] = [];
 
-  const spawnGroup = (index: number) => {
+  const spawnGroup = () => {
+    const value = Value({ value: (allEntities.length * 37) % 65 });
     const group = OrderedChildren
-      ? world.spawn(IsGroup, OrderedChildren, Value({ value: deterministicValue(index) }))
-      : world.spawn(IsGroup, Value({ value: deterministicValue(index) }));
+      ? world.spawn(IsGroup, OrderedChildren, value)
+      : world.spawn(IsGroup, value);
     allEntities.push(group);
     return group;
   };
 
-  const spawnLeaf = (index: number) => {
-    const leaf = world.spawn(IsObject, Value({ value: deterministicValue(index) }), TotalValue);
+  const spawnLeaf = () => {
+    const leaf = world.spawn(IsObject, Value({ value: (allEntities.length * 37) % 65 }), TotalValue);
     allEntities.push(leaf);
     return leaf;
   };
 
-  const linkChildToParent = (child: Entity, parent: Entity) => {
-    child.add(ChildOf(parent));
-    (childrenByEntityId[parent.id()] ??= []).push(child);
-  };
-
   let groupCycle = 0;
   let objectCycle = 0;
-  let created = 0;
   let pending: Entity[] = [];
 
-  const nextGroupCount = (remaining: number) => {
-    const count = groupChildrenCycle[groupCycle++ % groupChildrenCycle.length];
-    return Math.min(count, remaining);
-  };
-
-  const nextObjectCount = (remaining: number) => {
-    const count = objectChildrenCycle[objectCycle++ % objectChildrenCycle.length];
-    return Math.min(count, remaining);
-  };
-
-  const bottomLeafCount = Math.floor(cap * bottomLeafFraction);
-  for (let i = 0; i < bottomLeafCount && created < cap; i++) {
-    pending.push(spawnLeaf(created++));
+  const bottomLeafCount = Math.min(
+    targetEntityCount,
+    Math.floor(targetEntityCount * bottomLeafFraction)
+  );
+  for (let i = 0; i < bottomLeafCount; i++) {
+    pending.push(spawnLeaf());
   }
 
-  while (pending.length > 1 && created < cap) {
+  while (pending.length > 1 && allEntities.length < targetEntityCount) {
     const nextPending: Entity[] = [];
     let pendingIndex = 0;
 
-    while (pendingIndex < pending.length && created < cap) {
-      const adoptCount = nextGroupCount(pending.length - pendingIndex);
-      const group = spawnGroup(created++);
+    while (pendingIndex < pending.length && allEntities.length < targetEntityCount) {
+      const adoptCount = Math.min(
+        groupChildrenCycle[groupCycle++ % groupChildrenCycle.length],
+        pending.length - pendingIndex
+      );
+      const group = spawnGroup();
 
-      for (let i = 0; i < adoptCount && pendingIndex < pending.length; i++) {
-        linkChildToParent(pending[pendingIndex++], group);
+      for (let i = 0; i < adoptCount; i++) {
+        pending[pendingIndex++].add(ChildOf(group));
       }
 
-      const sprinkleCount = created < cap ? nextObjectCount(cap - created) : 0;
-      for (let i = 0; i < sprinkleCount && created < cap; i++) {
-        linkChildToParent(spawnLeaf(created++), group);
+      const sprinkleCount =
+        allEntities.length < targetEntityCount
+          ? Math.min(
+              objectChildrenCycle[objectCycle++ % objectChildrenCycle.length],
+              targetEntityCount - allEntities.length
+            )
+          : 0;
+      for (let i = 0; i < sprinkleCount; i++) {
+        spawnLeaf().add(ChildOf(group));
       }
 
       nextPending.push(group);
     }
 
-    for (; pendingIndex < pending.length; pendingIndex++) {
-      nextPending.push(pending[pendingIndex]);
-    }
-
-    pending = nextPending;
+    pending = nextPending.concat(pending.slice(pendingIndex));
   }
 
   const root =
@@ -145,103 +99,73 @@ function buildGraph(world: World, traits: Traits): SceneGraphBuild {
         : world.spawn(IsGroup, Value({ value: 0 }));
 
   if (pending.length > 1) {
-    for (let i = 0; i < pending.length; i++) {
-      linkChildToParent(pending[i], root);
+    for (const child of pending) {
+      child.add(ChildOf(root));
     }
   }
 
-  if (created < cap) {
+  if (allEntities.length < targetEntityCount) {
     const groups = world.query(IsGroup);
-    let groupIndex = 0;
-    while (created < cap) {
-      linkChildToParent(spawnLeaf(created++), groups[groupIndex++ % groups.length]);
+    for (let i = 0; allEntities.length < targetEntityCount; i++) {
+      spawnLeaf().add(ChildOf(groups[i % groups.length]));
     }
   }
 
-  const { depthByEntityId, subtreeSizeByEntityId } = analyzeGraph(root, childrenByEntityId);
-
-  return { allEntities, depthByEntityId, subtreeSizeByEntityId };
+  return allEntities;
 }
 
-function getEntityTraversalCost(
-  entity: Entity,
-  depthByEntityId: number[],
-  subtreeSizeByEntityId: number[]
-) {
-  return subtreeSizeByEntityId[entity.id()] + depthByEntityId[entity.id()];
-}
+function createDirtySystem(allEntities: Entity[], { ChildOf, Value }: Traits) {
+  const dirtyCount = Math.max(1, Math.floor(allEntities.length * CONFIG.dirtyFraction));
+  const candidatesByEntity = new Map(allEntities.map((entity) => [entity, { entity, cost: 1 }]));
 
-function selectLightestBatch(
-  dirtyBatches: Entity[][],
-  dirtyBatchCosts: number[],
-  dirtyCount: number
-) {
-  let bestBatchIndex = 0;
-
-  for (let i = 1; i < dirtyBatches.length; i++) {
-    if (dirtyBatches[i].length >= dirtyCount) continue;
-    if (dirtyBatches[bestBatchIndex].length >= dirtyCount) {
-      bestBatchIndex = i;
-      continue;
-    }
-    if (dirtyBatchCosts[i] < dirtyBatchCosts[bestBatchIndex]) {
-      bestBatchIndex = i;
+  // Each ancestor step adds an upward visit here and a descendant visit at the ancestor.
+  for (const candidate of candidatesByEntity.values()) {
+    for (
+      let parent = candidate.entity.targetFor(ChildOf);
+      parent;
+      parent = parent.targetFor(ChildOf)
+    ) {
+      candidate.cost++;
+      const ancestor = candidatesByEntity.get(parent);
+      if (ancestor) ancestor.cost++;
     }
   }
 
-  return bestBatchIndex;
-}
+  const candidates = [...candidatesByEntity.values()].sort(
+    (a, b) => b.cost - a.cost || a.entity - b.entity
+  );
+  const batches = Array.from(
+    { length: Math.max(1, Math.ceil(allEntities.length / dirtyCount)) },
+    () => ({
+      entities: [] as Entity[],
+      cost: 0,
+    })
+  );
 
-function createDirtyBatches(
-  allEntities: Entity[],
-  dirtyCount: number,
-  depthByEntityId: number[],
-  subtreeSizeByEntityId: number[]
-) {
-  const batchCount = Math.max(1, Math.ceil(allEntities.length / dirtyCount));
-  const dirtyBatches = Array.from({ length: batchCount }, () => [] as Entity[]);
-  const dirtyBatchCosts = Array.from({ length: batchCount }, () => 0);
-  const candidates = allEntities
-    .map((entity) => ({
-      entity,
-      cost: getEntityTraversalCost(entity, depthByEntityId, subtreeSizeByEntityId),
-    }))
-    .sort((a, b) => b.cost - a.cost || a.entity - b.entity);
-
-  // Greedy bin packing keeps each frame's total propagation cost close,
-  // while cycling through fixed precomputed batches preserves determinism.
-  for (let i = 0; i < candidates.length; i++) {
-    const candidate = candidates[i];
-    const batchIndex = selectLightestBatch(dirtyBatches, dirtyBatchCosts, dirtyCount);
-    dirtyBatches[batchIndex].push(candidate.entity);
-    dirtyBatchCosts[batchIndex] += candidate.cost;
+  // Assign expensive nodes first to the lightest batch that still has room.
+  for (const candidate of candidates) {
+    let lightest = batches[0];
+    for (const batch of batches) {
+      if (
+        batch.entities.length < dirtyCount &&
+        (lightest.entities.length >= dirtyCount || batch.cost < lightest.cost)
+      ) {
+        lightest = batch;
+      }
+    }
+    lightest.entities.push(candidate.entity);
+    lightest.cost += candidate.cost;
   }
 
-  // Top up any short batch with the cheapest entities so each frame dirties the same count.
+  // Fill short batches with cheap nodes so every frame dirties the same count.
   let fillerIndex = candidates.length - 1;
-  for (let i = 0; i < dirtyBatches.length; i++) {
-    while (dirtyBatches[i].length < dirtyCount) {
-      dirtyBatches[i].push(candidates[fillerIndex].entity);
+  for (const batch of batches) {
+    while (batch.entities.length < dirtyCount) {
+      batch.entities.push(candidates[fillerIndex].entity);
       fillerIndex = fillerIndex > 0 ? fillerIndex - 1 : candidates.length - 1;
     }
   }
-
-  return dirtyBatches;
-}
-
-function createDirtySystem(
-  allEntities: Entity[],
-  Value: Traits['Value'],
-  depthByEntityId: number[],
-  subtreeSizeByEntityId: number[]
-) {
-  const dirtyCount = Math.max(1, Math.floor(allEntities.length * CONFIG.dirtyFraction));
-  const dirtyBatches = createDirtyBatches(
-    allEntities,
-    dirtyCount,
-    depthByEntityId,
-    subtreeSizeByEntityId
-  );
+  const dirtyBatches = batches.map((batch) => batch.entities);
 
   let dirtyBatchIndex = 0;
   let frame = 0;
@@ -320,19 +244,17 @@ function createPropagateSystem(
 export function createSceneGraphContext(variant: SceneGraphVariant): SceneGraphContext {
   const world = createWorld();
   const traits = createTraits(variant);
-  const { allEntities, depthByEntityId, subtreeSizeByEntityId } = buildGraph(world, traits);
-
-  const dirtyImpl = createDirtySystem(
-    allEntities,
-    traits.Value,
-    depthByEntityId,
-    subtreeSizeByEntityId
-  );
+  const allEntities = buildGraph(world, traits);
+  const dirty = createDirtySystem(allEntities, traits);
   const propagate = createPropagateSystem(traits);
 
   return {
     world,
-    dirty: () => dirtyImpl(),
+    dirty,
     propagate,
+    snapshot: () =>
+      world
+        .query(traits.TotalValue)
+        .reduce((sum, entity) => sum + entity.get(traits.TotalValue)!.value, 0),
   };
 }

--- a/benches/scene-graph-propagation/scene-graph-propagation-not-exclusive.bench.ts
+++ b/benches/scene-graph-propagation/scene-graph-propagation-not-exclusive.bench.ts
@@ -4,10 +4,15 @@ import { createSchedule } from './systems/schedule.ts';
 
 /** @see scene-graph-propagation.bench.ts for description. */
 group('scene graph propagation: ChildOf not exclusive @scene @graph @relation', () => {
-  const ctx = createSceneGraphContext('child-of-not-exclusive');
-  const schedule = createSchedule(ctx);
+  bench(function* () {
+    const ctx = createSceneGraphContext('child-of-not-exclusive');
+    const schedule = createSchedule(ctx);
 
-  bench(() => {
-    schedule.run({ world: ctx.world });
-  }).gc('inner');
+    yield {
+      bench: () => schedule.run({ world: ctx.world }),
+      snapshot: ctx.snapshot,
+    };
+
+    ctx.world.destroy();
+  });
 });

--- a/benches/scene-graph-propagation/scene-graph-propagation-ordered-relation.bench.ts
+++ b/benches/scene-graph-propagation/scene-graph-propagation-ordered-relation.bench.ts
@@ -4,10 +4,15 @@ import { createSchedule } from './systems/schedule.ts';
 
 /** @see scene-graph-propagation.bench.ts for description. */
 group('scene graph propagation: OrderedRelation @scene @graph @relation', () => {
-  const ctx = createSceneGraphContext('ordered-relation');
-  const schedule = createSchedule(ctx);
+  bench(function* () {
+    const ctx = createSceneGraphContext('ordered-relation');
+    const schedule = createSchedule(ctx);
 
-  bench(() => {
-    schedule.run({ world: ctx.world });
-  }).gc('inner');
+    yield {
+      bench: () => schedule.run({ world: ctx.world }),
+      snapshot: ctx.snapshot,
+    };
+
+    ctx.world.destroy();
+  });
 });

--- a/benches/scene-graph-propagation/scene-graph-propagation.bench.ts
+++ b/benches/scene-graph-propagation/scene-graph-propagation.bench.ts
@@ -7,13 +7,18 @@ import { createSchedule } from './systems/schedule.ts';
  * each iteration dirties a small subset of nodes, walks up to collect ancestor state,
  * then propagates updated totals down through descendants using different child storage strategies.
  *
- * Each variant is in its own file for process isolation (labs runs each .bench.ts separately).
+ * Each variant runs in an isolated worker process.
  */
 group('scene graph propagation: ChildOf exclusive @scene @graph @relation', () => {
-  const ctx = createSceneGraphContext('child-of-exclusive');
-  const schedule = createSchedule(ctx);
+  bench(function* () {
+    const ctx = createSceneGraphContext('child-of-exclusive');
+    const schedule = createSchedule(ctx);
 
-  bench(() => {
-    schedule.run({ world: ctx.world });
-  }).gc('inner');
+    yield {
+      bench: () => schedule.run({ world: ctx.world }),
+      snapshot: ctx.snapshot,
+    };
+
+    ctx.world.destroy();
+  });
 });

--- a/packages/collections/benches/hi-sparse-bitset.bench.ts
+++ b/packages/collections/benches/hi-sparse-bitset.bench.ts
@@ -1,19 +1,16 @@
-import { bench, group } from '@pmndrs/labs';
+import { assert, bench, group } from '@pmndrs/labs';
 import { HiSparseBitSet, forEachIntersection, forEachQuery } from '../src';
 
 // --- Constants ---
 // All benchmarks use 10k elements so per-element cost is directly comparable.
 
 const N = 10_000;
-const PACKED = 1; // contiguous: ~312 bits/block, near-full
-const DISPERSED = 10; // moderate: ~31 bits/block, realistic ECS pattern
-const EXTREME = 1000; // pathological: ~1 bit/block
-
 type Regime = { name: string; stride: number };
 const REGIMES: Regime[] = [
-  { name: 'packed', stride: PACKED },
-  { name: 'dispersed', stride: DISPERSED },
-  { name: 'extreme', stride: EXTREME },
+  { name: 'packed', stride: 1 },
+  { name: 'dispersed', stride: 10 },
+  // Keep even the disjoint sets within the bitset's 2^20 index capacity.
+  { name: 'extreme', stride: 50 },
 ];
 
 function filledSet(n: number, stride: number): HiSparseBitSet {
@@ -27,15 +24,16 @@ function filledSet(n: number, stride: number): HiSparseBitSet {
 group('insert 10k @bitset', () => {
   for (const { name, stride } of REGIMES) {
     bench(name, function* () {
-      const set = new HiSparseBitSet();
+      let set: HiSparseBitSet;
       const limit = N * stride;
       yield {
-        bench: () => {
+        0: () => (set = new HiSparseBitSet()),
+        bench: (set: HiSparseBitSet) => {
           for (let i = 0; i < limit; i += stride) set.insert(i);
         },
-        after: () => set.clear(),
+        snapshot: () => set.size,
       };
-    }).gc('inner');
+    });
   }
 });
 
@@ -46,10 +44,16 @@ group('has 10k (hit) @bitset', () => {
     bench(name, function* () {
       const set = filledSet(N, stride);
       const limit = N * stride;
-      yield () => {
-        for (let i = 0; i < limit; i += stride) set.has(i);
+      const result = yield () => {
+        let hits = 0;
+        for (let i = 0; i < limit; i += stride) {
+          if (set.has(i)) hits++;
+        }
+        return hits;
       };
-    }).gc('inner');
+      assert.equal(result, N);
+      return result;
+    });
   }
 });
 
@@ -58,11 +62,18 @@ group('has 10k (miss) @bitset', () => {
     bench(name, function* () {
       const set = filledSet(N, stride);
       const limit = N * stride;
-      // Offset by 1 so every lookup misses
-      yield () => {
-        for (let i = 1; i < limit; i += stride) set.has(i);
+      // Packed misses follow the populated range, sparse misses fall in the gaps.
+      const offset = stride === 1 ? N : 1;
+      const result = yield () => {
+        let hits = 0;
+        for (let i = offset; i < limit + offset; i += stride) {
+          if (set.has(i)) hits++;
+        }
+        return hits;
       };
-    }).gc('inner');
+      assert.equal(result, 0);
+      return result;
+    });
   }
 });
 
@@ -71,17 +82,16 @@ group('has 10k (miss) @bitset', () => {
 group('remove 10k @bitset', () => {
   for (const { name, stride } of REGIMES) {
     bench(name, function* () {
-      let set = filledSet(N, stride);
+      let set: HiSparseBitSet;
       const limit = N * stride;
       yield {
-        bench: () => {
+        0: () => (set = filledSet(N, stride)),
+        bench: (set: HiSparseBitSet) => {
           for (let i = 0; i < limit; i += stride) set.remove(i);
         },
-        after: () => {
-          set = filledSet(N, stride);
-        },
+        snapshot: () => set.size,
       };
-    }).gc('inner');
+    });
   }
 });
 
@@ -91,28 +101,37 @@ group('forEach 10k @bitset', () => {
   for (const { name, stride } of REGIMES) {
     bench(name, function* () {
       const set = filledSet(N, stride);
-      yield () => {
-        set.forEach(() => {});
+      const result = yield () => {
+        let sum = 0;
+        set.forEach((index) => {
+          sum += index;
+        });
+        return sum;
       };
-    }).gc('inner');
+      return result;
+    });
   }
 });
 
 // --- drain 10k ---
 
-group('drain 10k @bitset', () => {
+group('drain 10k @bitset @drain', () => {
   for (const { name, stride } of REGIMES) {
     bench(name, function* () {
-      let set = filledSet(N, stride);
+      let set: HiSparseBitSet;
+      let checksum = 0;
       yield {
-        bench: () => {
-          set.drain(() => {});
+        0: () => (set = filledSet(N, stride)),
+        bench: (set: HiSparseBitSet) => {
+          checksum = 0;
+          set.drain((index) => {
+            checksum += index;
+          });
+          return checksum;
         },
-        after: () => {
-          set = filledSet(N, stride);
-        },
+        snapshot: () => [set.size, checksum],
       };
-    }).gc('inner');
+    });
   }
 });
 
@@ -120,24 +139,26 @@ group('drain 10k @bitset', () => {
 
 group('setRange vs insert 10k @bitset', () => {
   bench('setRange', function* () {
-    const set = new HiSparseBitSet();
+    let set: HiSparseBitSet;
     yield {
-      bench: () => {
+      0: () => (set = new HiSparseBitSet()),
+      bench: (set: HiSparseBitSet) => {
         set.setRange(0, N);
       },
-      after: () => set.clear(),
+      snapshot: () => set.size,
     };
-  }).gc('inner');
+  });
 
   bench('insert loop', function* () {
-    const set = new HiSparseBitSet();
+    let set: HiSparseBitSet;
     yield {
-      bench: () => {
+      0: () => (set = new HiSparseBitSet()),
+      bench: (set: HiSparseBitSet) => {
         for (let i = 0; i < N; i++) set.insert(i);
       },
-      after: () => set.clear(),
+      snapshot: () => set.size,
     };
-  }).gc('inner');
+  });
 });
 
 // --- forEachIntersection ---
@@ -148,10 +169,8 @@ group('intersection 2-way 10k result @bitset', () => {
     bench(name, function* () {
       const a = filledSet(N, stride);
       const b = filledSet(N, stride);
-      yield () => {
-        forEachIntersection([a, b], () => {});
-      };
-    }).gc('inner');
+      return yield () => forEachIntersection([a, b], () => {});
+    });
   }
 });
 
@@ -163,13 +182,11 @@ group('intersection 4-way @bitset', () => {
   for (const { name, stride } of REGIMES) {
     bench(name, function* () {
       const a = filledSet(N, stride);
-      const b = filledSet(N * 2, stride * 2);
-      const c = filledSet(N * 3, stride * 3);
-      const d = filledSet(N * 5, stride * 5);
-      yield () => {
-        forEachIntersection([a, b, c, d], () => {});
-      };
-    }).gc('inner');
+      const b = filledSet(Math.ceil(N / 2), stride * 2);
+      const c = filledSet(Math.ceil(N / 3), stride * 3);
+      const d = filledSet(Math.ceil(N / 5), stride * 5);
+      return yield () => forEachIntersection([a, b, c, d], () => {});
+    });
   }
 });
 
@@ -182,10 +199,8 @@ group('intersection 2-way disjoint @bitset', () => {
       const b = new HiSparseBitSet();
       const limit = N * stride * 2;
       for (let i = stride; i < limit; i += stride * 2) b.insert(i);
-      yield () => {
-        forEachIntersection([a, b], () => {});
-      };
-    }).gc('inner');
+      return yield () => forEachIntersection([a, b], () => {});
+    });
   }
 });
 
@@ -197,11 +212,9 @@ group('query req+forb 10k, 10% excluded @bitset', () => {
     bench(name, function* () {
       const req = filledSet(N, stride);
       // Forbidden hits every 10th element of req
-      const forb = filledSet(N, stride * 10);
-      yield () => {
-        forEachQuery([req], [forb], () => {});
-      };
-    }).gc('inner');
+      const forb = filledSet(Math.ceil(N / 10), stride * 10);
+      return yield () => forEachQuery([req], [forb], () => {});
+    });
   }
 });
 
@@ -209,11 +222,9 @@ group('query 2 req + 1 forb @bitset', () => {
   for (const { name, stride } of REGIMES) {
     bench(name, function* () {
       const a = filledSet(N, stride);
-      const b = filledSet(N * 2, stride * 2);
-      const forb = filledSet(N, stride * 10);
-      yield () => {
-        forEachQuery([a, b], [forb], () => {});
-      };
-    }).gc('inner');
+      const b = filledSet(Math.ceil(N / 2), stride * 2);
+      const forb = filledSet(Math.ceil(N / 10), stride * 10);
+      return yield () => forEachQuery([a, b], [forb], () => {});
+    });
   }
 });

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -12,7 +12,7 @@
     "bench": "labs"
   },
   "dependencies": {
-    "@pmndrs/labs": "^0.6.0"
+    "@pmndrs/labs": "^0.9.0"
   },
   "devDependencies": {
     "@config/oxlint": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,14 +75,17 @@ importers:
   benches:
     dependencies:
       '@pmndrs/labs':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.9.0
+        version: 0.9.0
       directed:
         specifier: 'catalog:'
         version: 0.1.6(@types/react@19.2.6)(react@19.2.8)
       koota:
         specifier: workspace:*
         version: link:../packages/publish
+      math:
+        specifier: 1.0.0-canary-37519dcd-20260903
+        version: 1.0.0-canary-37519dcd-20260903
     devDependencies:
       '@config/typescript':
         specifier: workspace:*
@@ -380,8 +383,8 @@ importers:
   packages/collections:
     dependencies:
       '@pmndrs/labs':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.9.0
+        version: 0.9.0
     devDependencies:
       '@config/oxlint':
         specifier: workspace:*
@@ -664,11 +667,13 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@clack/core@1.0.1':
-    resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.0.1':
-    resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1097,9 +1102,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pmndrs/labs@0.6.0':
-    resolution: {integrity: sha512-RBGGNfUgMR6mYh+u7nhPqvPga/gFZaEXUMmkv6vJj0y7JrTT4c0+1fu0H3aQaSMoH/VcCtB6I4ai1i4FB6f3kg==}
-    engines: {node: '>=25.0.0', pnpm: '>=10.0.0'}
+  '@pmndrs/labs@0.9.0':
+    resolution: {integrity: sha512-drIrOj8A4NOLEvPRsUD5pifbZxjnDSarfJQTMuRr9x6V0yWzver6t/1KmlMB3hHqKsBP5wgX57ElU+ZwqvFcQw==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
 
   '@quansync/fs@1.0.0':
@@ -1982,6 +1987,15 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2227,6 +2241,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math@1.0.0-canary-37519dcd-20260903:
+    resolution: {integrity: sha512-aul1nzD8ob5wKMKVQqOXe5ufT/xmiTHxObL81J2ImgNRwpRg+r7IeWOQ2WnD5W/cvpZc7gySwXs0YjVpDtahTQ==}
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
@@ -2597,6 +2614,11 @@ packages:
 
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -3062,15 +3084,16 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@clack/core@1.0.1':
+  '@clack/core@1.4.3':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.0.1':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 1.0.1
-      picocolors: 1.1.1
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@csstools/color-helpers@5.1.0': {}
@@ -3316,10 +3339,10 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.80.0':
     optional: true
 
-  '@pmndrs/labs@0.6.0':
+  '@pmndrs/labs@0.9.0':
     dependencies:
-      '@clack/prompts': 1.0.1
-      tsx: 4.22.4
+      '@clack/prompts': 1.7.0
+      tsx: 4.23.13
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -4038,6 +4061,16 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -4270,6 +4303,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  math@1.0.0-canary-37519dcd-20260903: {}
 
   mdn-data@2.12.2: {}
 
@@ -4619,6 +4654,12 @@ snapshots:
       - vue-tsc
 
   tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsx@4.23.13:
     dependencies:
       esbuild: 0.28.2
     optionalDependencies:


### PR DESCRIPTION
Labs gets and update and with it some correctness testing. We also fix some benches:

- Fixed mutation resets so repeated runs perform real work and commit pending query removals. Bitset mutations get fresh inputs for every invocation.
- Strengthened relation toggle snapshots to catch skipped toggles, and drain snapshots to catch clearing without visiting values.
- Fixed packed bitset “miss” lookups and kept fixtures within the supported index range.
- Seeded relation churn with math, making starting worlds reproducible across comparison blocks.