### PR TITLE
Add entity lifecycle subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,21 @@ const unsub = world.onAdd(Likes, (entity, target) => {
 })
 ```
 
+### Per-entity events
+
+The same hooks exist on entities and subscribe to only that entity's events.
+
+```js
+const entity = world.spawn(Position)
+
+const unsub = entity.onChange(Position, (entity) => {
+  console.log(`Position changed to ${entity.get(Position).x}`)
+})
+
+entity.onAdd(Position, (entity) => {})
+entity.onRemove(Position, (entity) => {})
+```
+
 ### Change detection with `updateEach`
 
 By default, `updateEach` will automatically turn on change detection for traits that are being tracked via `onChange` or the `Changed` modifier. If you want to silence change detection for a loop or force it to always run, you can do so with an options config.

--- a/benches/change-subscriptions/change-subscriptions.bench.ts
+++ b/benches/change-subscriptions/change-subscriptions.bench.ts
@@ -1,0 +1,42 @@
+import { assert, bench, group } from '@pmndrs/labs';
+import { createWorld, trait, type Entity } from 'koota';
+
+const Position = trait({ x: 0, y: 0 });
+
+// One subscriber per entity, the shape every framework hook produces.
+// world.onChange fans every set out to every subscriber, so N changes is N * N calls.
+// entity.onChange dispatches only to that entity's subscribers.
+group('change subscriptions per entity @change @subscription', () => {
+  for (const count of [500, 1000, 2000]) {
+    for (const scope of ['world', 'entity'] as const) {
+      bench(`${scope}.onChange, ${count} subscribers, ${count} changed`, function* () {
+        const world = createWorld();
+        const entities: Entity[] = [];
+        let hits = 0;
+
+        for (let i = 0; i < count; i++) {
+          const entity = world.spawn(Position);
+          entities.push(entity);
+          if (scope === 'world') {
+            world.onChange(Position, (e) => {
+              if (e === entity) hits++;
+            });
+          } else {
+            entity.onChange(Position, () => hits++);
+          }
+        }
+
+        yield () => {
+          hits = 0;
+          for (let i = 0; i < count; i++) {
+            entities[i].set(Position, { x: i, y: i });
+          }
+        };
+
+        world.destroy();
+        assert.equal(hits, count);
+        return hits;
+      });
+    }
+  }
+});

--- a/benches/entity-operations/entity-operations.bench.ts
+++ b/benches/entity-operations/entity-operations.bench.ts
@@ -123,6 +123,47 @@ group('entity.destroy 10k @entity', () => {
   });
 });
 
+group('entity.destroy subscription cleanup 10k @entity @subscription @cleanup', () => {
+  for (const traitCount of [8, 128, 1024]) {
+    for (const subscribed of [false, true]) {
+      bench(
+        `${traitCount} traits, ${subscribed ? 'with subscriptions' : 'no subscriptions'}`,
+        function* () {
+          const Position = trait({ x: 0 });
+          const world = createWorld();
+          world.spawn(Position, ...Array.from({ length: traitCount - 1 }, () => trait())).destroy();
+
+          const entities: Entity[] = [];
+          const notify = () => {};
+          const spawn = () => {
+            for (let i = 0; i < 10_000; i++) {
+              const entity = world.spawn(Position);
+              entities[i] = entity;
+              if (subscribed) {
+                // Framework hooks subscribe to all three lifecycle events.
+                entity.onAdd(Position, notify);
+                entity.onRemove(Position, notify);
+                entity.onChange(Position, notify);
+              }
+            }
+          };
+          spawn();
+
+          yield {
+            bench: () => {
+              for (let i = 0; i < entities.length; i++) entities[i].destroy();
+            },
+            snapshot: () => entities.filter((entity) => world.has(entity)).length,
+            after: spawn,
+          };
+
+          world.destroy();
+        }
+      );
+    }
+  }
+});
+
 group('entity get set 10k @entity', () => {
   bench('entity.get', function* () {
     const world = createWorld();

--- a/packages/core/spec/structural.md
+++ b/packages/core/spec/structural.md
@@ -96,7 +96,7 @@ After the entity is structurally committed, trait data is initialized from schem
 **8. Call add hooks**
 
 ```ts
-for (const sub of data.addSubscriptions) sub(entity)
+emit(data.addSubscriptions, entity)
 ```
 
 Fire `onAdd` subscriptions for this trait, letting listeners react to the structural change. Hooks run after values are set so listeners can read the initialized data.

--- a/packages/core/src/entity/entity-methods-patch.ts
+++ b/packages/core/src/entity/entity-methods-patch.ts
@@ -4,7 +4,9 @@ import type { Relation, RelationPair } from '../relation/types';
 import { addTrait, getTrait, removeTrait, setTrait } from '../trait/trait';
 import type { ConfigurableTrait, Trait } from '../trait/types';
 import { universe } from '../universe/universe';
-import { destroyEntity, entityHas, getEntityContext } from './entity';
+import type { Subscriber } from '../trait/subscriptions';
+import type { HookInput } from '../world/utils/resolve-hook';
+import { destroyEntity, entityHas, getEntityContext, subscribeEntityEvent } from './entity';
 import type { Entity } from './types';
 import { getEntityGeneration, getEntityId } from './utils/pack-entity';
 
@@ -46,6 +48,21 @@ Number.prototype.set = function (
   triggerChanged = true
 ) {
   setTrait(getEntityContext(this), this, trait, value, triggerChanged);
+};
+
+// @ts-expect-error
+Number.prototype.onAdd = function (this: Entity, input: HookInput, callback: Subscriber) {
+  return subscribeEntityEvent(getEntityContext(this), this, 'addSubscriptions', input, callback);
+};
+
+// @ts-expect-error
+Number.prototype.onRemove = function (this: Entity, input: HookInput, callback: Subscriber) {
+  return subscribeEntityEvent(getEntityContext(this), this, 'removeSubscriptions', input, callback);
+};
+
+// @ts-expect-error
+Number.prototype.onChange = function (this: Entity, input: HookInput, callback: Subscriber) {
+  return subscribeEntityEvent(getEntityContext(this), this, 'changeSubscriptions', input, callback);
 };
 
 //@ts-expect-error

--- a/packages/core/src/entity/entity.ts
+++ b/packages/core/src/entity/entity.ts
@@ -3,10 +3,19 @@ import { IsExcluded, queryInternal } from '../query/query';
 import { getEntitiesWithRelationTo, getRelationTargets, hasRelationPair } from '../relation/relation';
 import type { RelationPair } from '../relation/types';
 import { isRelationPair } from '../relation/utils/is-relation';
-import { addTrait, cleanupRelationTarget, hasTrait, removeTrait } from '../trait/trait';
+import { clearEntity, subscribeEntity, type Subscriber } from '../trait/subscriptions';
+import {
+  addTrait,
+  cleanupRelationTarget,
+  hasTrait,
+  registerTrait,
+  removeTrait,
+} from '../trait/trait';
+import { getTraitInstance, hasTraitInstance } from '../trait/trait-instance';
 import type { ConfigurableTrait, Trait } from '../trait/types';
 import { universe } from '../universe/universe';
 import type { WorldContext } from '../world';
+import { resolveHookCallback, resolveHookTrait, type HookInput } from '../world/utils/resolve-hook';
 import type { Entity } from './types';
 import { allocateEntity, isEntityAlive, releaseEntity } from './utils/entity-index';
 import { getEntityId } from './utils/pack-entity';
@@ -90,6 +99,21 @@ export function destroyEntity(ctx: WorldContext, entity: Entity) {
 
     ctx.entityTraits.delete(currentEntity);
 
+    // Drop entity subscribers so a recycled id never inherits them. Instances
+    // that no longer hold any are pruned from the index here.
+    for (const instance of ctx.entitySubscribedInstances) {
+      clearEntity(instance.addSubscriptions, currentEntity);
+      clearEntity(instance.removeSubscriptions, currentEntity);
+      clearEntity(instance.changeSubscriptions, currentEntity);
+      if (
+        instance.addSubscriptions.entityCount === 0 &&
+        instance.removeSubscriptions.entityCount === 0 &&
+        instance.changeSubscriptions.entityCount === 0
+      ) {
+        ctx.entitySubscribedInstances.delete(instance);
+      }
+    }
+
     const eid = getEntityId(currentEntity);
     const pageId = eid >>> 10;
     const offset = eid & 1023;
@@ -115,4 +139,24 @@ export function entityHas(ctx: WorldContext, entity: Entity, trait: Trait | Rela
     );
   }
   return hasRelationPair(ctx, entity, trait);
+}
+
+/**
+ * Subscribe to a trait event for one entity. The instance is indexed on the
+ * world so destroy only visits traits that hold entity subscribers.
+ * A dead handle registers nothing, since its id may already belong to another entity.
+ */
+export function subscribeEntityEvent(
+  ctx: WorldContext,
+  entity: Entity,
+  event: 'addSubscriptions' | 'removeSubscriptions' | 'changeSubscriptions',
+  input: HookInput,
+  callback: Subscriber
+) {
+  if (!isEntityAlive(ctx.entityIndex, entity)) return () => {};
+  const trait = resolveHookTrait(input);
+  if (!hasTraitInstance(ctx.traitInstances, trait)) registerTrait(ctx, trait);
+  const instance = getTraitInstance(ctx.traitInstances, trait)!;
+  ctx.entitySubscribedInstances.add(instance);
+  return subscribeEntity(instance[event], entity, resolveHookCallback(ctx, input, callback));
 }

--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -8,6 +8,26 @@ import type {
   TraitValue,
 } from '../trait/types';
 
+/**
+ * Entity scoped lifecycle hooks. Same inputs and callbacks as the world hooks,
+ * but only fire for this entity so the callback needs no identity check.
+ */
+type EntityHook = {
+  <T extends Trait>(trait: T, callback: (entity: Entity) => void): () => void;
+  <T extends Trait>(
+    relation: Relation<T>,
+    callback: (entity: Entity, target: Entity) => void
+  ): () => void;
+  <T extends Trait>(
+    pair: RelationPair<T>,
+    callback: (entity: Entity, target: Entity) => void
+  ): () => void;
+  (
+    input: Trait | Relation<Trait> | RelationPair,
+    callback: (entity: Entity, target?: Entity) => void
+  ): () => void;
+};
+
 export type Entity = number & {
   add: (...traits: ConfigurableTrait[]) => void;
   remove: (...traits: (Trait | RelationPair)[]) => void;
@@ -22,6 +42,9 @@ export type Entity = number & {
   get: <T extends Trait | RelationPair>(trait: T) => TraitRecord<ExtractSchema<T>> | undefined;
   targetFor: <T extends Trait>(relation: Relation<T>) => Entity | undefined;
   targetsFor: <T extends Trait>(relation: Relation<T>) => Entity[];
+  onAdd: EntityHook;
+  onRemove: EntityHook;
+  onChange: EntityHook;
   id: () => number;
   generation: () => number;
   isAlive: () => boolean;

--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -3,6 +3,7 @@ import type { Entity } from '../../entity/types';
 import { getEntityId } from '../../entity/utils/pack-entity';
 import { ensureMaskPage } from '../../entity/utils/paged-mask';
 import { isRelation } from '../../relation/utils/is-relation';
+import { emit, hasSubscribers } from '../../trait/subscriptions';
 import { hasTrait, registerTrait } from '../../trait/trait';
 import { getTraitInstance, hasTraitInstance } from '../../trait/trait-instance';
 import type { ExtractTraits, Trait, TraitOrRelation } from '../../trait/types';
@@ -64,12 +65,12 @@ function markChanged(ctx: WorldContext, entity: Entity, trait: Trait) {
 
 export function setChanged(ctx: WorldContext, entity: Entity, trait: Trait) {
   const data = markChanged(ctx, entity, trait);
-  if (!data) return;
-  for (const sub of data.changeSubscriptions) sub(entity);
+  if (data && hasSubscribers(data.changeSubscriptions)) emit(data.changeSubscriptions, entity);
 }
 
 export function setPairChanged(ctx: WorldContext, entity: Entity, trait: Trait, target: Entity) {
   const data = markChanged(ctx, entity, trait);
-  if (!data) return;
-  for (const sub of data.changeSubscriptions) sub(entity, target);
+  if (data && hasSubscribers(data.changeSubscriptions)) {
+    emit(data.changeSubscriptions, entity, target);
+  }
 }

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -8,6 +8,8 @@ import { Store } from '../storage';
 import { getStore } from '../trait/trait';
 import type { Trait } from '../trait/types';
 import { shallowEqual } from '../utils/shallow-equal';
+import { hasSubscribers } from '../trait/subscriptions';
+import { getTraitInstance } from '../trait/trait-instance';
 import type { WorldContext } from '../world';
 import { isModifier } from './modifier';
 import { setChanged } from './modifiers/changed';
@@ -198,7 +200,8 @@ export function createQueryResult<T extends QueryParameter[]>(
 ) {
   for (let i = 0; i < traits.length; i++) {
     const trait = traits[i];
-    const hasTracked = ctx.trackedTraits.has(trait);
+    const instance = getTraitInstance(ctx.traitInstances, trait);
+    const hasTracked = instance !== undefined && hasSubscribers(instance.changeSubscriptions);
     const hasChanged = query.hasChangedModifiers && query.changedTraits.has(trait);
 
     if (hasTracked || hasChanged) trackedIndices.push(i);

--- a/packages/core/src/relation/ordered.ts
+++ b/packages/core/src/relation/ordered.ts
@@ -56,11 +56,11 @@ export function setupOrderedTraitSync(ctx: WorldContext, orderedTrait: OrderedRe
 
   type RelationSub = (entity: Entity, target: Entity) => void;
 
-  (relationInstance.addSubscriptions as Set<RelationSub>).add((child, parent) => {
+  (relationInstance.addSubscriptions.all as Set<RelationSub>).add((child, parent) => {
     getList(parent)?._appendWithoutSync(child);
   });
 
-  (relationInstance.removeSubscriptions as Set<RelationSub>).add((child, parent) => {
+  (relationInstance.removeSubscriptions.all as Set<RelationSub>).add((child, parent) => {
     const eid = getEntityId(parent);
     const denseIdx = entityIndex.sparse[eid];
     if (denseIdx !== undefined && getEntityId(entityIndex.dense[denseIdx]) === eid) {

--- a/packages/core/src/trait/subscriptions.ts
+++ b/packages/core/src/trait/subscriptions.ts
@@ -1,0 +1,115 @@
+import type { Entity } from '../entity/types';
+import { getEntityId } from '../entity/utils/pack-entity';
+
+export type Subscriber = (entity: Entity, target?: Entity) => void;
+
+/** A slot holds one subscriber directly and only becomes a Set on the second subscriber. */
+type Slot = Subscriber | Set<Subscriber>;
+
+/**
+ * Subscribers for one trait event. World subscribers fire for every entity.
+ * Entity subscribers are paged by entity id like the masks and fire for one
+ * entity, so dispatch does not scale with the number of subscribed entities.
+ * entityCount lets emit and destroy skip the page lookup when nothing is registered.
+ */
+export type Subscriptions = {
+  all: Set<Subscriber>;
+  byEntity: ((Slot | undefined)[] | undefined)[];
+  /** Number of entities with at least one subscriber. */
+  entityCount: number;
+};
+
+export function createSubscriptions(): Subscriptions {
+  return { all: new Set(), byEntity: [], entityCount: 0 };
+}
+
+/** @inline */
+export function hasSubscribers(subs: Subscriptions): boolean {
+  return subs.all.size !== 0 || subs.entityCount !== 0;
+}
+
+export function subscribeEntity(
+  subs: Subscriptions,
+  entity: Entity,
+  callback: Subscriber
+): () => void {
+  const eid = getEntityId(entity);
+  const pageId = eid >>> 10;
+  const offset = eid & 1023;
+
+  let page = subs.byEntity[pageId];
+  if (!page) page = subs.byEntity[pageId] = [];
+
+  const slot = page[offset];
+  if (slot === undefined) {
+    page[offset] = callback;
+    subs.entityCount++;
+  } else if (typeof slot === 'function') {
+    if (slot !== callback) {
+      page[offset] = new Set([slot, callback]);
+    }
+  } else {
+    slot.add(callback);
+  }
+
+  return () => {
+    // A dead entity was cleared on destroy and its id may now belong to another entity.
+    if (!entity.isAlive()) return;
+    const current = page[offset];
+    if (current === undefined) return;
+    if (current === callback) {
+      page[offset] = undefined;
+      subs.entityCount--;
+    } else if (typeof current !== 'function' && current.delete(callback) && current.size === 0) {
+      page[offset] = undefined;
+      subs.entityCount--;
+    }
+  };
+}
+
+/** Drop every entity subscriber for an entity so a recycled id never inherits them. */
+export function clearEntity(subs: Subscriptions, entity: Entity) {
+  if (subs.entityCount === 0) return;
+  const eid = getEntityId(entity);
+  const page = subs.byEntity[eid >>> 10];
+  if (!page) return;
+  const slot = page[eid & 1023];
+  if (slot === undefined) return;
+  // Stops an in-flight dispatch that is still iterating this set.
+  if (typeof slot !== 'function') slot.clear();
+  page[eid & 1023] = undefined;
+  subs.entityCount--;
+}
+
+/**
+ * Invoke world subscribers then entity subscribers. The entity slot is read
+ * after the world subscribers run so one of them can unsubscribe it. Plain
+ * traits call with the entity alone so callbacks keep their one argument arity.
+ */
+export function emit(subs: Subscriptions, entity: Entity, target?: Entity) {
+  if (target === undefined) {
+    for (const sub of subs.all) sub(entity);
+    const slot = getSlot(subs, entity);
+    if (slot === undefined) return;
+    if (typeof slot === 'function') slot(entity);
+    else for (const sub of slot) sub(entity);
+  } else {
+    for (const sub of subs.all) sub(entity, target);
+    const slot = getSlot(subs, entity);
+    if (slot === undefined) return;
+    if (typeof slot === 'function') slot(entity, target);
+    else for (const sub of slot) sub(entity, target);
+  }
+}
+
+/**
+ * A world subscriber may have destroyed the entity and spawned a replacement on
+ * the same id, so the slot is only read for the generation the event belongs to.
+ */
+/** @inline */
+function getSlot(subs: Subscriptions, entity: Entity): Slot | undefined {
+  if (subs.entityCount === 0 || !entity.isAlive()) return undefined;
+  const eid = getEntityId(entity);
+  const page = subs.byEntity[eid >>> 10];
+  return page && page[eid & 1023];
+}

--- a/packages/core/src/trait/trait.ts
+++ b/packages/core/src/trait/trait.ts
@@ -35,6 +35,7 @@ import {
 } from '../storage';
 import type { World, WorldContext } from '../world';
 import { incrementWorldBitflag } from '../world/utils/increment-world-bit-flag';
+import { createSubscriptions, emit } from './subscriptions';
 import { getTraitInstance, hasTraitInstance, setTraitInstance } from './trait-instance';
 import type {
   ConfigurableTrait,
@@ -103,9 +104,9 @@ export function registerTrait(ctx: WorldContext, trait: Trait) {
     notQueries: new Set(),
     relationQueries: new Set(),
     schema: trait.schema,
-    changeSubscriptions: new Set(),
-    addSubscriptions: new Set(),
-    removeSubscriptions: new Set(),
+    changeSubscriptions: createSubscriptions(),
+    addSubscriptions: createSubscriptions(),
+    removeSubscriptions: createSubscriptions(),
   };
 
   setTraitInstance(ctx.traitInstances, trait, data);
@@ -162,7 +163,7 @@ export function addTrait(ctx: WorldContext, entity: Entity, ...traits: Configura
       setTrait(ctx, entity, trait, params, false);
     }
 
-    for (const sub of data.addSubscriptions) sub(entity);
+    emit(data.addSubscriptions, entity);
   }
 }
 
@@ -182,9 +183,7 @@ export function addTrait(ctx: WorldContext, entity: Entity, ...traits: Configura
     const oldTarget = getFirstRelationTarget(ctx, relation, entity);
     if (oldTarget !== undefined && oldTarget !== target) {
       const instance = getTraitInstance(ctx.traitInstances, relationTrait);
-      if (instance) {
-        for (const sub of instance.removeSubscriptions) sub(entity, oldTarget);
-      }
+      if (instance) emit(instance.removeSubscriptions, entity, oldTarget);
       removeRelationTarget(ctx, relation, entity, oldTarget);
     }
   }
@@ -204,7 +203,7 @@ export function addTrait(ctx: WorldContext, entity: Entity, ...traits: Configura
   }
 
   instance = instance ?? getTraitInstance(ctx.traitInstances, relationTrait)!;
-  for (const sub of instance.addSubscriptions) sub(entity, target);
+  emit(instance.addSubscriptions, entity, target);
 }
 
 export function removeTrait(ctx: WorldContext, entity: Entity, ...traits: (Trait | RelationPair)[]) {
@@ -224,16 +223,12 @@ export function removeTrait(ctx: WorldContext, entity: Entity, ...traits: (Trait
       const instance = getTraitInstance(ctx.traitInstances, trait);
       if (instance) {
         const targets = getRelationTargets(ctx, traitCtx.relation, entity);
-        for (const t of targets) {
-          for (const sub of instance.removeSubscriptions) sub(entity, t);
-        }
+        for (const t of targets) emit(instance.removeSubscriptions, entity, t);
       }
       removeAllRelationTargets(ctx, traitCtx.relation, entity);
     } else {
       const instance = getTraitInstance(ctx.traitInstances, trait);
-      if (instance) {
-        for (const sub of instance.removeSubscriptions) sub(entity);
-      }
+      if (instance) emit(instance.removeSubscriptions, entity);
     }
 
     removeTraitFromEntity(ctx, entity, trait);
@@ -252,9 +247,7 @@ export function removeTrait(ctx: WorldContext, entity: Entity, ...traits: (Trait
   if (target === '*') {
     if (instance) {
       const targets = getRelationTargets(ctx, relation, entity);
-      for (const t of targets) {
-        for (const sub of instance.removeSubscriptions) sub(entity, t);
-      }
+      for (const t of targets) emit(instance.removeSubscriptions, entity, t);
     }
     removeAllRelationTargets(ctx, relation, entity);
     removeTraitFromEntity(ctx, entity, relationTrait);
@@ -262,9 +255,7 @@ export function removeTrait(ctx: WorldContext, entity: Entity, ...traits: (Trait
   }
 
   if (typeof target === 'number') {
-    if (instance) {
-      for (const sub of instance.removeSubscriptions) sub(entity, target);
-    }
+    if (instance) emit(instance.removeSubscriptions, entity, target);
 
     const { removedIndex, wasLastTarget } = removeRelationTarget(ctx, relation, entity, target);
     if (removedIndex === -1) return;
@@ -282,9 +273,7 @@ export function cleanupRelationTarget(
   const relationTrait = relation[$internal].trait;
 
   const instance = getTraitInstance(ctx.traitInstances, relationTrait);
-  if (instance) {
-    for (const sub of instance.removeSubscriptions) sub(entity, target);
-  }
+  if (instance) emit(instance.removeSubscriptions, entity, target);
 
   const { removedIndex, wasLastTarget } = removeRelationTarget(ctx, relation, entity, target);
   if (removedIndex === -1) return;

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -3,6 +3,7 @@ import type { Entity } from '../entity/types';
 import type { QueryInstance } from '../query/types';
 import type { Relation, RelationPair } from '../relation/types';
 import type { AoSFactory, Schema, Store, StoreType } from '../storage';
+import type { Subscriptions } from './subscriptions';
 
 // Backwards-compatible alias (the trait "type" is the storage layout).
 export type TraitType = StoreType;
@@ -86,9 +87,9 @@ export interface TraitInstance<T extends Trait = Trait, S extends Schema = Extra
   /** Queries that filter by this relation (only for relation traits) */
   relationQueries: Set<QueryInstance>;
   schema: S;
-  changeSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
-  addSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
-  removeSubscriptions: Set<(entity: Entity, target?: Entity) => void>;
+  changeSubscriptions: Subscriptions;
+  addSubscriptions: Subscriptions;
+  removeSubscriptions: Subscriptions;
   /**
    * Paged relation targets.
    * For exclusive: relationTargets[pageId][offset] = targetId (number)

--- a/packages/core/src/world/types.ts
+++ b/packages/core/src/world/types.ts
@@ -37,16 +37,13 @@ export type WorldContext = {
   trackingSnapshots: Map<number, Uint32Array[][]>;
   changedMasks: Map<number, Uint32Array[][]>;
   worldEntity: Entity;
-  trackedTraits: Set<Trait>;
+  entitySubscribedInstances: Set<TraitInstance>;
   resetSubscriptions: Set<() => void>;
   entitySpawnSubscriptions: Set<(entity: Entity) => void>;
   entityDestroySubscriptions: Set<(entity: Entity) => void>;
   traitRegisteredSubscriptions: Set<(trait: Trait) => void>;
-  /** Whether this world has been lazily registered in the universe. */
   isRegistered: boolean;
-  /** Pending initial traits to apply on first registration. */
   pendingTraits: ConfigurableTrait[] | undefined;
-  /** FR cleanup token (shared ownedPages with entityIndex). */
   cleanupToken: import('../entity/utils/page-allocator').PageCleanupToken | null;
 };
 

--- a/packages/core/src/world/utils/resolve-hook.ts
+++ b/packages/core/src/world/utils/resolve-hook.ts
@@ -1,0 +1,49 @@
+import { $internal } from '../../common';
+import type { Entity } from '../../entity/types';
+import { createQuery, queryInternal } from '../../query/query';
+import { isQuery } from '../../query/utils/is-query';
+import type { Relation, RelationPair } from '../../relation/types';
+import { isRelation, isRelationPair } from '../../relation/utils/is-relation';
+import type { Subscriber } from '../../trait/subscriptions';
+import type { Trait } from '../../trait/types';
+import type { WorldContext } from '../types';
+
+export type HookInput = Trait | Relation<Trait> | RelationPair<Trait>;
+
+/** Resolve the trait that backs a hook input so subscriptions attach to one trait instance. */
+export function resolveHookTrait(input: HookInput): Trait {
+  if (isRelationPair(input)) return input.relation[$internal].trait;
+  if (isRelation(input)) return input[$internal].trait;
+  return input;
+}
+
+/** Wrap a hook callback so relation pairs only fire for their target. */
+export function resolveHookCallback(
+  ctx: WorldContext,
+  input: HookInput,
+  callback: Subscriber
+): Subscriber {
+  if (!isRelationPair(input)) return callback;
+
+  const pairTargetQuery = input.targetQuery;
+  if (pairTargetQuery) {
+    const targetQuery = isQuery(pairTargetQuery) ? pairTargetQuery : createQuery(...pairTargetQuery);
+
+    return (entity: Entity, target?: Entity) => {
+      /**
+       * @todo This should be using the same caching logic as the query system
+       * instead of searching with `includes`.
+       */
+      if (target !== undefined && queryInternal(ctx, targetQuery).includes(target)) {
+        callback(entity, target);
+      }
+    };
+  }
+
+  const pairTarget = input.target;
+  if (pairTarget === '*') return callback;
+
+  return (entity: Entity, target?: Entity) => {
+    if (target === pairTarget) callback(entity, target);
+  };
+}

--- a/packages/core/src/world/world.ts
+++ b/packages/core/src/world/world.ts
@@ -9,7 +9,7 @@ import {
 } from '../entity/utils/entity-index';
 import type { PageCleanupToken } from '../entity/utils/page-allocator';
 import { createEmptyMaskGeneration } from '../entity/utils/paged-mask';
-import { IsExcluded, createQuery, createQueryInstance } from '../query/query';
+import { IsExcluded, createQueryInstance } from '../query/query';
 import { createRelationOnlyQueryResult } from '../query/query-result';
 import type { Query, QueryInstance, QueryParameter, QueryUnsubscriber } from '../query/types';
 import { createQueryHash } from '../query/utils/create-query-hash';
@@ -17,7 +17,7 @@ import { isQuery } from '../query/utils/is-query';
 import { getTrackingCursor, setTrackingMasks } from '../query/utils/tracking-cursor';
 import { getEntitiesWithRelationTo } from '../relation/relation';
 import type { Relation, RelationPair } from '../relation/types';
-import { isRelation, isRelationPair } from '../relation/utils/is-relation';
+import { isRelationPair } from '../relation/utils/is-relation';
 import { addTrait, getTrait, hasTrait, registerTrait, removeTrait, setTrait } from '../trait/trait';
 import { clearTraitInstance, getTraitInstance, hasTraitInstance } from '../trait/trait-instance';
 import type {
@@ -30,6 +30,7 @@ import type {
 } from '../trait/types';
 import { universe } from '../universe/universe';
 import type { World, WorldContext } from './types';
+import { resolveHookCallback, resolveHookTrait } from './utils/resolve-hook';
 
 let nextWorldId = 0;
 
@@ -58,45 +59,6 @@ function ensureWorldRegistered(ctx: WorldContext, world: World, id: number): voi
 
 export function createWorld(...traits: ConfigurableTrait[]): World {
   const id = nextWorldId++;
-  type HookInput = Trait | Relation<Trait> | RelationPair<Trait>;
-  type HookCallback = (entity: Entity, target?: Entity) => void;
-
-  function resolveHookTrait(input: HookInput): Trait {
-    if (isRelationPair(input)) return input.relation[$internal].trait;
-    if (isRelation(input)) return input[$internal].trait;
-    return input;
-  }
-
-  function resolveHookCallback(input: HookInput, callback: HookCallback): HookCallback {
-    if (isRelationPair(input)) {
-      const pairTargetQuery = input.targetQuery;
-      if (pairTargetQuery) {
-        const targetQuery = isQuery(pairTargetQuery)
-          ? pairTargetQuery
-          : createQuery(...pairTargetQuery);
-
-        return (entity: Entity, target?: Entity) => {
-          /**
-           * @todo This should be using the same caching logic as the query system
-           * instead of searching with `includes`.
-           */
-          if (target !== undefined && world.query(targetQuery).includes(target)) {
-            callback(entity, target);
-          }
-        };
-      }
-
-      const pairTarget = input.target;
-      if (pairTarget === '*') return callback;
-
-      return (entity: Entity, target?: Entity) => {
-        if (target === pairTarget) callback(entity, target);
-      };
-    }
-
-    return callback;
-  }
-
   const pendingTraits = traits.length > 0 ? traits : undefined;
 
   const cleanupToken: PageCleanupToken = {
@@ -123,7 +85,7 @@ export function createWorld(...traits: ConfigurableTrait[]): World {
       trackingSnapshots: new Map(),
       changedMasks: new Map(),
       worldEntity: null!,
-      trackedTraits: new Set(),
+      entitySubscribedInstances: new Set(),
       resetSubscriptions: new Set(),
       entitySpawnSubscriptions: new Set(),
       entityDestroySubscriptions: new Set(),
@@ -228,7 +190,7 @@ export function createWorld(...traits: ConfigurableTrait[]): World {
       ctx.trackingSnapshots.clear();
       ctx.dirtyMasks.clear();
       ctx.changedMasks.clear();
-      ctx.trackedTraits.clear();
+      ctx.entitySubscribedInstances.clear();
 
       ctx.worldEntity = createEntity(ctx, IsExcluded);
 
@@ -368,7 +330,7 @@ export function createWorld(...traits: ConfigurableTrait[]): World {
       const ctx = world[$internal];
       ensureWorldRegistered(ctx, world, id);
       const resolvedTrait = resolveHookTrait(trait);
-      const resolvedCallback = resolveHookCallback(trait, callback);
+      const resolvedCallback = resolveHookCallback(ctx, trait, callback);
 
       let data = getTraitInstance(ctx.traitInstances, resolvedTrait);
 
@@ -377,9 +339,9 @@ export function createWorld(...traits: ConfigurableTrait[]): World {
         data = getTraitInstance(ctx.traitInstances, resolvedTrait)!;
       }
 
-      data.addSubscriptions.add(resolvedCallback);
+      data.addSubscriptions.all.add(resolvedCallback);
 
-      return () => data.addSubscriptions.delete(resolvedCallback);
+      return () => data.addSubscriptions.all.delete(resolvedCallback);
     },
 
     onRemove<T extends Trait>(
@@ -389,7 +351,7 @@ export function createWorld(...traits: ConfigurableTrait[]): World {
       const ctx = world[$internal];
       ensureWorldRegistered(ctx, world, id);
       const resolvedTrait = resolveHookTrait(trait);
-      const resolvedCallback = resolveHookCallback(trait, callback);
+      const resolvedCallback = resolveHookCallback(ctx, trait, callback);
 
       let data = getTraitInstance(ctx.traitInstances, resolvedTrait);
 
@@ -398,31 +360,26 @@ export function createWorld(...traits: ConfigurableTrait[]): World {
         data = getTraitInstance(ctx.traitInstances, resolvedTrait)!;
       }
 
-      data.removeSubscriptions.add(resolvedCallback);
+      data.removeSubscriptions.all.add(resolvedCallback);
 
-      return () => data.removeSubscriptions.delete(resolvedCallback);
+      return () => data.removeSubscriptions.all.delete(resolvedCallback);
     },
 
     onChange(
       trait: Trait | Relation<Trait> | RelationPair<Trait>,
       callback: (entity: Entity, target?: Entity) => void
-    ) {
+    ): QueryUnsubscriber {
       const ctx = world[$internal];
       ensureWorldRegistered(ctx, world, id);
       const resolvedTrait = resolveHookTrait(trait);
-      const resolvedCallback = resolveHookCallback(trait, callback);
+      const resolvedCallback = resolveHookCallback(ctx, trait, callback);
 
       if (!hasTraitInstance(ctx.traitInstances, resolvedTrait)) registerTrait(ctx, resolvedTrait);
 
       const data = getTraitInstance(ctx.traitInstances, resolvedTrait)!;
-      data.changeSubscriptions.add(resolvedCallback);
+      data.changeSubscriptions.all.add(resolvedCallback);
 
-      ctx.trackedTraits.add(resolvedTrait);
-
-      return () => {
-        data.changeSubscriptions.delete(resolvedCallback);
-        if (data.changeSubscriptions.size === 0) ctx.trackedTraits.delete(resolvedTrait);
-      };
+      return () => data.changeSubscriptions.all.delete(resolvedCallback);
     },
 
     onEntitySpawn(callback: (entity: Entity) => void): QueryUnsubscriber {

--- a/packages/core/tests/lifecycle.test.ts
+++ b/packages/core/tests/lifecycle.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createQuery, createWorld, relation, trait, type Entity, type TraitRecord } from '../src';
+import {
+  $internal,
+  createQuery,
+  createWorld,
+  relation,
+  trait,
+  type Entity,
+  type TraitRecord,
+} from '../src';
 
 const Position = trait({ x: 0, y: 0 });
 const Name = trait({ name: 'name' });
@@ -141,6 +149,246 @@ describe('Lifecycle Subscriptions', () => {
       const entityB = world.spawn();
       entityB.add(Position({ x: 1, y: 2 }));
       expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('entity.onAdd / onRemove / onChange', () => {
+    it('only fires for the subscribed entity', () => {
+      const entityA = world.spawn();
+      const entityB = world.spawn();
+
+      const addCb = vi.fn();
+      const removeCb = vi.fn();
+      const changeCb = vi.fn();
+      entityA.onAdd(Position, addCb);
+      entityA.onRemove(Position, removeCb);
+      entityA.onChange(Position, changeCb);
+
+      entityB.add(Position);
+      entityB.set(Position, { x: 1, y: 1 });
+      entityB.remove(Position);
+      expect(addCb).not.toHaveBeenCalled();
+      expect(changeCb).not.toHaveBeenCalled();
+      expect(removeCb).not.toHaveBeenCalled();
+
+      entityA.add(Position);
+      entityA.set(Position, { x: 1, y: 1 });
+      entityA.remove(Position);
+      expect(addCb).toHaveBeenCalledWith(entityA);
+      expect(changeCb).toHaveBeenCalledWith(entityA);
+      expect(removeCb).toHaveBeenCalledWith(entityA);
+    });
+
+    it('fires alongside world subscribers and stops after unsubscribe', () => {
+      const entity = world.spawn(Position);
+      const worldCb = vi.fn();
+      const entityCb = vi.fn();
+      world.onChange(Position, worldCb);
+      const unsub = entity.onChange(Position, entityCb);
+
+      entity.set(Position, { x: 1, y: 1 });
+      expect(worldCb).toHaveBeenCalledTimes(1);
+      expect(entityCb).toHaveBeenCalledTimes(1);
+
+      unsub();
+      unsub();
+      entity.set(Position, { x: 2, y: 2 });
+      expect(worldCb).toHaveBeenCalledTimes(2);
+      expect(entityCb).toHaveBeenCalledTimes(1);
+    });
+
+    it('enables change detection in updateEach', () => {
+      const entity = world.spawn(Position);
+      const cb = vi.fn();
+      const unsub = entity.onChange(Position, cb);
+
+      world.query(Position).updateEach(([position]) => {
+        position.x = 5;
+      });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      unsub();
+      world.query(Position).updateEach(([position]) => {
+        position.x = 6;
+      });
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops subscribers when the entity is destroyed so a recycled id is clean', () => {
+      const entity = world.spawn(Position);
+      const cb = vi.fn();
+      const unsub = entity.onChange(Position, cb);
+      entity.destroy();
+
+      const recycled = world.spawn(Position);
+      expect(recycled.id()).toBe(entity.id());
+      recycled.set(Position, { x: 1, y: 1 });
+      expect(cb).not.toHaveBeenCalled();
+
+      // Late unsubscribe after destroy is a safe no-op.
+      unsub();
+      const again = vi.fn();
+      recycled.onChange(Position, again);
+      recycled.set(Position, { x: 2, y: 2 });
+      expect(again).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps tracking for new subscribers when a stale unsubscribe runs after reset', () => {
+      const stale = world.spawn(Position).onChange(Position, vi.fn());
+      world.reset();
+
+      const entity = world.spawn(Position);
+      const cb = vi.fn();
+      entity.onChange(Position, cb);
+      stale();
+
+      world.query(Position).updateEach(([position]) => {
+        position.x = 1;
+      });
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('counts a callback registered twice once', () => {
+      const entity = world.spawn(Position);
+      const cb = vi.fn();
+      const unsubA = entity.onChange(Position, cb);
+      const unsubB = entity.onChange(Position, cb);
+
+      entity.set(Position, { x: 1, y: 1 });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      unsubA();
+      unsubB();
+      world.query(Position).updateEach(([position]) => {
+        position.x = 2;
+      });
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports several subscribers on one entity and removes them independently', () => {
+      const entity = world.spawn(Position);
+      const a = vi.fn();
+      const b = vi.fn();
+      const c = vi.fn();
+      const unsubA = entity.onChange(Position, a);
+      const unsubB = entity.onChange(Position, b);
+      const unsubC = entity.onChange(Position, c);
+
+      entity.set(Position, { x: 1, y: 1 });
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+      expect(c).toHaveBeenCalledTimes(1);
+
+      unsubB();
+      entity.set(Position, { x: 2, y: 2 });
+      expect(a).toHaveBeenCalledTimes(2);
+      expect(b).toHaveBeenCalledTimes(1);
+      expect(c).toHaveBeenCalledTimes(2);
+
+      unsubA();
+      unsubC();
+      world.query(Position).updateEach(([position]) => {
+        position.x = 3;
+      });
+      expect(a).toHaveBeenCalledTimes(2);
+      expect(c).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores a late unsubscribe that shares a callback with a recycled id', () => {
+      const cb = vi.fn();
+      const stale = world.spawn(Position);
+      const unsub = stale.onChange(Position, cb);
+      stale.destroy();
+
+      const recycled = world.spawn(Position);
+      expect(recycled.id()).toBe(stale.id());
+      recycled.onChange(Position, cb);
+      unsub();
+
+      recycled.set(Position, { x: 1, y: 1 });
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not invoke a listener removed or destroyed during dispatch', () => {
+      const entity = world.spawn(Position);
+      const removed = vi.fn();
+      const unsub = entity.onChange(Position, removed);
+      const worldUnsub = world.onChange(Position, () => unsub());
+
+      entity.set(Position, { x: 1, y: 1 });
+      expect(removed).not.toHaveBeenCalled();
+      worldUnsub();
+
+      const victim = world.spawn(Position);
+      const late = vi.fn();
+      victim.onChange(Position, () => victim.destroy());
+      victim.onChange(Position, late);
+
+      victim.set(Position, { x: 1, y: 1 });
+      expect(late).not.toHaveBeenCalled();
+    });
+
+    it('registers nothing for a destroyed handle', () => {
+      const dead = world.spawn();
+      dead.destroy();
+
+      const cb = vi.fn();
+      const unsub = dead.onAdd(Position, cb);
+
+      const recycled = world.spawn();
+      expect(recycled.id()).toBe(dead.id());
+      recycled.add(Position);
+      expect(cb).not.toHaveBeenCalled();
+      unsub();
+    });
+
+    it('does not deliver a dead generation event to a replacement on the same id', () => {
+      const original = world.spawn(Position);
+      const replacementCb = vi.fn();
+      const worldUnsub = world.onChange(Position, (e) => {
+        if (e !== original) return;
+        e.destroy();
+        const replacement = world.spawn(Position);
+        expect(replacement.id()).toBe(original.id());
+        replacement.onChange(Position, replacementCb);
+      });
+
+      original.set(Position, { x: 1, y: 1 });
+      expect(replacementCb).not.toHaveBeenCalled();
+      worldUnsub();
+    });
+
+    it('filters relation pairs by target', () => {
+      const ChildOf = relation({ store: { priority: 0 } });
+      const parentA = world.spawn();
+      const parentB = world.spawn();
+      const child = world.spawn();
+
+      const pairCb = vi.fn();
+      const relationCb = vi.fn();
+      child.onAdd(ChildOf(parentA), pairCb);
+      child.onChange(ChildOf, relationCb);
+
+      child.add(ChildOf(parentB));
+      expect(pairCb).not.toHaveBeenCalled();
+
+      child.add(ChildOf(parentA));
+      expect(pairCb).toHaveBeenCalledWith(child, parentA);
+
+      child.set(ChildOf(parentB), { priority: 1 });
+      expect(relationCb).toHaveBeenCalledWith(child, parentB);
+    });
+
+    it('works on the world entity', () => {
+      const TimeOfDay = trait({ hour: 0 });
+      const localWorld = createWorld(TimeOfDay);
+      const cb = vi.fn();
+      localWorld[$internal].worldEntity.onChange(TimeOfDay, cb);
+
+      localWorld.set(TimeOfDay, { hour: 1 });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      localWorld.destroy();
     });
   });
 

--- a/packages/react/src/hooks/use-has.ts
+++ b/packages/react/src/hooks/use-has.ts
@@ -1,27 +1,18 @@
-import {
-  $internal,
-  $relationPair,
-  type Entity,
-  type RelationPair,
-  type Trait,
-  type World,
-} from '@koota/core';
+import { $relationPair, type Entity, type RelationPair, type Trait, type World } from '@koota/core';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
-import { isWorld } from '../utils/is-world';
+import { getTargetEntity } from '../utils/get-target-entity';
 import { useStableTrait } from '../utils/use-stable-pair';
-import { useWorld } from '../world/use-world';
 
 export function useHas(
   target: Entity | World | undefined | null,
   trait: Trait | RelationPair
 ): boolean {
-  const contextWorld = useWorld();
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
   const stableTrait = useStableTrait(trait);
 
   const memo = useMemo(
-    () => (target ? createSubscriptions(target, stableTrait, contextWorld) : undefined),
-    [target, stableTrait, contextWorld]
+    () => (target ? createSubscriptions(target, stableTrait) : undefined),
+    [target, stableTrait]
   );
 
   const valueRef = useRef<boolean>(false);
@@ -50,13 +41,8 @@ export function useHas(
   return valueRef.current;
 }
 
-function createSubscriptions(
-  target: Entity | World,
-  trait: Trait | RelationPair,
-  contextWorld: World
-) {
-  const world = isWorld(target) ? target : contextWorld;
-  const entity = isWorld(target) ? target[$internal].worldEntity : target;
+function createSubscriptions(target: Entity | World, trait: Trait | RelationPair) {
+  const entity = getTargetEntity(target);
 
   // Wildcard pairs like ChildOf('*') fire on every pair removal, but the entity
   // may still have other pairs. Since onRemove fires before state cleanup,
@@ -67,12 +53,9 @@ function createSubscriptions(
   return {
     entity,
     subscribe: (setValue: (value: boolean) => void) => {
-      const onAddUnsub = world.onAdd(trait, (e) => {
-        if (e === entity) setValue(true);
-      });
+      const onAddUnsub = entity.onAdd(trait, () => setValue(true));
 
-      const onRemoveUnsub = world.onRemove(trait, (e) => {
-        if (e !== entity) return;
+      const onRemoveUnsub = entity.onRemove(trait, () => {
         if (wildcardRelation) {
           setValue(entity.targetsFor(wildcardRelation).length > 1);
         } else {

--- a/packages/react/src/hooks/use-tag.ts
+++ b/packages/react/src/hooks/use-tag.ts
@@ -1,16 +1,11 @@
-import { $internal, type Entity, type TagTrait, type World } from '@koota/core';
+import { type Entity, type TagTrait, type World } from '@koota/core';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
-import { isWorld } from '../utils/is-world';
-import { useWorld } from '../world/use-world';
+import { getTargetEntity } from '../utils/get-target-entity';
 
 export function useTag(target: Entity | World | undefined | null, tag: TagTrait): boolean {
-  const contextWorld = useWorld();
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
-  const memo = useMemo(
-    () => (target ? createSubscriptions(target, tag, contextWorld) : undefined),
-    [target, tag, contextWorld]
-  );
+  const memo = useMemo(() => (target ? createSubscriptions(target, tag) : undefined), [target, tag]);
 
   const valueRef = useRef<boolean>(false);
   const memoRef = useRef(memo);
@@ -39,20 +34,14 @@ export function useTag(target: Entity | World | undefined | null, tag: TagTrait)
   return valueRef.current;
 }
 
-function createSubscriptions(target: Entity | World, tag: TagTrait, contextWorld: World) {
-  const world = isWorld(target) ? target : contextWorld;
-  const entity = isWorld(target) ? target[$internal].worldEntity : target;
+function createSubscriptions(target: Entity | World, tag: TagTrait) {
+  const entity = getTargetEntity(target);
 
   return {
     entity,
     subscribe: (setValue: (value: boolean) => void) => {
-      const onAddUnsub = world.onAdd(tag, (e) => {
-        if (e === entity) setValue(true);
-      });
-
-      const onRemoveUnsub = world.onRemove(tag, (e) => {
-        if (e === entity) setValue(false);
-      });
+      const onAddUnsub = entity.onAdd(tag, () => setValue(true));
+      const onRemoveUnsub = entity.onRemove(tag, () => setValue(false));
 
       setValue(entity.has(tag));
 

--- a/packages/react/src/hooks/use-target.ts
+++ b/packages/react/src/hooks/use-target.ts
@@ -1,18 +1,16 @@
-import { $internal, type Entity, type Relation, type Trait, type World } from '@koota/core';
+import { type Entity, type Relation, type Trait, type World } from '@koota/core';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
-import { isWorld } from '../utils/is-world';
-import { useWorld } from '../world/use-world';
+import { getTargetEntity } from '../utils/get-target-entity';
 
 export function useTarget<T extends Trait>(
   target: Entity | World | undefined | null,
   relation: Relation<T>
 ): Entity | undefined {
-  const contextWorld = useWorld();
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
   const memo = useMemo(
-    () => (target ? createSubscriptions(target, relation, contextWorld) : undefined),
-    [target, relation, contextWorld]
+    () => (target ? createSubscriptions(target, relation) : undefined),
+    [target, relation]
   );
 
   const valueRef = useRef<Entity | undefined>(undefined);
@@ -42,28 +40,15 @@ export function useTarget<T extends Trait>(
   return valueRef.current;
 }
 
-function createSubscriptions<T extends Trait>(
-  target: Entity | World,
-  relation: Relation<T>,
-  contextWorld: World
-) {
-  const world = isWorld(target) ? target : contextWorld;
-  const entity = isWorld(target) ? target[$internal].worldEntity : target;
+function createSubscriptions<T extends Trait>(target: Entity | World, relation: Relation<T>) {
+  const entity = getTargetEntity(target);
 
   return {
     entity,
     subscribe: (setValue: (value: Entity | undefined) => void) => {
-      const onAddUnsub = world.onAdd(relation, (e) => {
-        if (e === entity) setValue(entity.targetFor(relation));
-      });
-
-      const onRemoveUnsub = world.onRemove(relation, (e) => {
-        if (e === entity) setValue(undefined);
-      });
-
-      const onChangeUnsub = world.onChange(relation, (e) => {
-        if (e === entity) setValue(entity.targetFor(relation));
-      });
+      const onAddUnsub = entity.onAdd(relation, () => setValue(entity.targetFor(relation)));
+      const onRemoveUnsub = entity.onRemove(relation, () => setValue(undefined));
+      const onChangeUnsub = entity.onChange(relation, () => setValue(entity.targetFor(relation)));
 
       setValue(entity.targetFor(relation));
 

--- a/packages/react/src/hooks/use-targets.ts
+++ b/packages/react/src/hooks/use-targets.ts
@@ -1,18 +1,16 @@
-import { $internal, type Entity, type Relation, type Trait, type World } from '@koota/core';
+import { type Entity, type Relation, type Trait, type World } from '@koota/core';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
-import { isWorld } from '../utils/is-world';
-import { useWorld } from '../world/use-world';
+import { getTargetEntity } from '../utils/get-target-entity';
 
 export function useTargets<T extends Trait>(
   target: Entity | World | undefined | null,
   relation: Relation<T>
 ): Entity[] {
-  const contextWorld = useWorld();
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
   const memo = useMemo(
-    () => (target ? createSubscriptions(target, relation, contextWorld) : undefined),
-    [target, relation, contextWorld]
+    () => (target ? createSubscriptions(target, relation) : undefined),
+    [target, relation]
   );
 
   const valueRef = useRef<Entity[]>([]);
@@ -42,13 +40,8 @@ export function useTargets<T extends Trait>(
   return valueRef.current;
 }
 
-function createSubscriptions<T extends Trait>(
-  target: Entity | World,
-  relation: Relation<T>,
-  contextWorld: World
-) {
-  const world = isWorld(target) ? target : contextWorld;
-  const entity = isWorld(target) ? target[$internal].worldEntity : target;
+function createSubscriptions<T extends Trait>(target: Entity | World, relation: Relation<T>) {
+  const entity = getTargetEntity(target);
 
   return {
     entity,
@@ -61,18 +54,14 @@ function createSubscriptions<T extends Trait>(
         setValue(value);
       };
 
-      const onAddUnsub = world.onAdd(relation, (e) => {
-        if (e === entity) update(entity.targetsFor(relation));
-      });
+      const onAddUnsub = entity.onAdd(relation, () => update(entity.targetsFor(relation)));
 
       // onRemove fires before data is removed, so filter out the target
-      const onRemoveUnsub = world.onRemove(relation, (e, t) => {
-        if (e === entity) update(currentValue.filter((p) => p !== t));
+      const onRemoveUnsub = entity.onRemove(relation, (_, t) => {
+        update(currentValue.filter((p) => p !== t));
       });
 
-      const onChangeUnsub = world.onChange(relation, (e) => {
-        if (e === entity) update(entity.targetsFor(relation));
-      });
+      const onChangeUnsub = entity.onChange(relation, () => update(entity.targetsFor(relation)));
 
       update(entity.targetsFor(relation));
 

--- a/packages/react/src/hooks/use-trait-effect.ts
+++ b/packages/react/src/hooks/use-trait-effect.ts
@@ -1,5 +1,4 @@
 import {
-  $internal,
   type Entity,
   type RelationPair,
   type Trait,
@@ -7,9 +6,8 @@ import {
   type World,
 } from '@koota/core';
 import { useEffect, useMemo, useRef } from 'react';
-import { isWorld } from '../utils/is-world';
+import { getTargetEntity } from '../utils/get-target-entity';
 import { useStableTrait } from '../utils/use-stable-pair';
-import { useWorld } from '../world/use-world';
 
 export function useTraitEffect<T extends Trait>(
   target: Entity | World,
@@ -26,26 +24,22 @@ export function useTraitEffect<T extends Trait>(
   trait: T | RelationPair<T>,
   callback: (value: TraitRecord<T> | undefined) => void
 ) {
-  const contextWorld = useWorld();
-  const world = useMemo(() => (isWorld(target) ? target : contextWorld), [target, contextWorld]);
-  const entity = useMemo(() => (isWorld(target) ? target[$internal].worldEntity : target), [target]);
+  const entity = useMemo(() => getTargetEntity(target), [target]);
   const stableTrait = useStableTrait(trait);
 
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
 
   useEffect(() => {
-    const onChangeUnsub = world.onChange(stableTrait, (e) => {
-      if (e === entity) callbackRef.current(e.get(stableTrait));
+    const onChangeUnsub = entity.onChange(stableTrait, () => {
+      callbackRef.current(entity.get(stableTrait));
     });
 
-    const onAddUnsub = world.onAdd(stableTrait, (e) => {
-      if (e === entity) callbackRef.current(e.get(stableTrait));
+    const onAddUnsub = entity.onAdd(stableTrait, () => {
+      callbackRef.current(entity.get(stableTrait));
     });
 
-    const onRemoveUnsub = world.onRemove(stableTrait, (e) => {
-      if (e === entity) callbackRef.current(undefined);
-    });
+    const onRemoveUnsub = entity.onRemove(stableTrait, () => callbackRef.current(undefined));
 
     callbackRef.current(entity.has(stableTrait) ? entity.get(stableTrait) : undefined);
 
@@ -54,5 +48,5 @@ export function useTraitEffect<T extends Trait>(
       onAddUnsub();
       onRemoveUnsub();
     };
-  }, [stableTrait, world, entity]);
+  }, [stableTrait, entity]);
 }

--- a/packages/react/src/hooks/use-trait.ts
+++ b/packages/react/src/hooks/use-trait.ts
@@ -1,5 +1,4 @@
 import {
-  $internal,
   shallowEqual,
   type Entity,
   type RelationPair,
@@ -8,9 +7,8 @@ import {
   type World,
 } from '@koota/core';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
-import { isWorld } from '../utils/is-world';
+import { getTargetEntity } from '../utils/get-target-entity';
 import { useStableTrait } from '../utils/use-stable-pair';
-import { useWorld } from '../world/use-world';
 
 /**
  * Making sure the values are never stale requires syncing at each boundary.
@@ -25,15 +23,14 @@ export function useTrait<T extends Trait>(
   target: Entity | World | undefined | null,
   trait: T | RelationPair<T>
 ): TraitRecord<T> | undefined {
-  const contextWorld = useWorld();
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
   const valueRef = useRef<TraitRecord<T> | undefined>(undefined);
   const memoRef = useRef<ReturnType<typeof createSubscriptions<T>> | undefined>(undefined);
   const stableTrait = useStableTrait(trait);
 
   const memo = useMemo(
-    () => (target ? createSubscriptions(target, stableTrait, contextWorld) : undefined),
-    [target, stableTrait, contextWorld]
+    () => (target ? createSubscriptions(target, stableTrait) : undefined),
+    [target, stableTrait]
   );
 
   // Reads the trait value synchronously
@@ -63,29 +60,15 @@ export function useTrait<T extends Trait>(
   return valueRef.current;
 }
 
-function createSubscriptions<T extends Trait>(
-  target: Entity | World,
-  trait: T | RelationPair<T>,
-  contextWorld: World
-) {
-  // Use the context world unless the target is a world itself
-  const world = isWorld(target) ? target : contextWorld;
-  const entity = isWorld(target) ? target[$internal].worldEntity : target;
+function createSubscriptions<T extends Trait>(target: Entity | World, trait: T | RelationPair<T>) {
+  const entity = getTargetEntity(target);
 
   return {
     entity,
     subscribe: (setValue: (value: TraitRecord<T> | undefined) => void) => {
-      const onChangeUnsub = world.onChange(trait, (e) => {
-        if (e === entity) setValue(e.get(trait));
-      });
-
-      const onAddUnsub = world.onAdd(trait, (e) => {
-        if (e === entity) setValue(e.get(trait));
-      });
-
-      const onRemoveUnsub = world.onRemove(trait, (e) => {
-        if (e === entity) setValue(undefined);
-      });
+      const onChangeUnsub = entity.onChange(trait, () => setValue(entity.get(trait)));
+      const onAddUnsub = entity.onAdd(trait, () => setValue(entity.get(trait)));
+      const onRemoveUnsub = entity.onRemove(trait, () => setValue(undefined));
 
       // Set initial value
       setValue(entity.has(trait) ? entity.get(trait) : undefined);

--- a/packages/react/src/utils/get-target-entity.ts
+++ b/packages/react/src/utils/get-target-entity.ts
@@ -1,0 +1,10 @@
+import { $internal, type Entity, type World } from '@koota/core';
+import { isWorld } from './is-world';
+
+/** Resolve the entity a hook subscribes to. A world resolves to its world entity. */
+export function getTargetEntity(target: Entity | World): Entity {
+  if (!isWorld(target)) return target;
+  // Adding no traits registers a lazy world so its entity exists.
+  if (!target.isRegistered) target.add();
+  return target[$internal].worldEntity;
+}

--- a/packages/svelte/src/hooks/use-has.svelte.ts
+++ b/packages/svelte/src/hooks/use-has.svelte.ts
@@ -6,15 +6,12 @@ import {
   type World,
 } from '@koota/core';
 import { getTargetEntity } from '../utils/get-target-entity.js';
-import { isWorld } from '../utils/is-world.js';
 import { type MaybeGetter, resolve } from '../utils/resolve.js';
-import { useWorld } from '../world/world-context.js';
 
 export function useHas(
   target: () => Entity | World | undefined | null,
   trait: MaybeGetter<Trait | RelationPair>
 ): { readonly current: boolean } {
-  const contextWorld = useWorld();
   const initialEntity = getTargetEntity(target());
   let value = $state(initialEntity?.has(resolve(trait)) ?? false);
 
@@ -27,8 +24,7 @@ export function useHas(
     }
 
     const resolvedTrait = resolve(trait);
-    const world = isWorld(t) ? t : contextWorld;
-    let entity: Entity;
+    const entity = getTargetEntity(t)!;
 
     // Wildcard pairs like ChildOf('*') fire on every pair removal, but the entity
     // may still have other pairs. Since onRemove fires before state cleanup,
@@ -37,16 +33,11 @@ export function useHas(
       !!(resolvedTrait as any)?.[relationPair] && (resolvedTrait as RelationPair).target === '*';
     const wildcardRelation = isWildcard ? (resolvedTrait as RelationPair).relation : undefined;
 
-    /**
-     * Subscribe before reading worldEntity: world.onAdd triggers lazy
-     * registration so worldEntity is guaranteed to exist after this.
-     */
-    const onAddUnsub = world.onAdd(resolvedTrait, (e) => {
-      if (e === entity) value = true;
+    const onAddUnsub = entity.onAdd(resolvedTrait, () => {
+      value = true;
     });
 
-    const onRemoveUnsub = world.onRemove(resolvedTrait, (e) => {
-      if (e !== entity) return;
+    const onRemoveUnsub = entity.onRemove(resolvedTrait, () => {
       if (wildcardRelation) {
         value = entity.targetsFor(wildcardRelation).length > 1;
       } else {
@@ -54,7 +45,6 @@ export function useHas(
       }
     });
 
-    entity = getTargetEntity(t)!;
     value = entity.has(resolvedTrait);
 
     return () => {

--- a/packages/svelte/src/hooks/use-tag.svelte.ts
+++ b/packages/svelte/src/hooks/use-tag.svelte.ts
@@ -1,14 +1,11 @@
 import { type Entity, type TagTrait, type World } from '@koota/core';
 import { getTargetEntity } from '../utils/get-target-entity.js';
-import { isWorld } from '../utils/is-world.js';
 import { type MaybeGetter, resolve } from '../utils/resolve.js';
-import { useWorld } from '../world/world-context.js';
 
 export function useTag(
   target: () => Entity | World | undefined | null,
   tag: MaybeGetter<TagTrait>
 ): { readonly current: boolean } {
-  const contextWorld = useWorld();
   const initialEntity = getTargetEntity(target());
   let value = $state(initialEntity?.has(resolve(tag)) ?? false);
 
@@ -21,23 +18,16 @@ export function useTag(
     }
 
     const resolvedTag = resolve(tag);
-    const world = isWorld(t) ? t : contextWorld;
+    const entity = getTargetEntity(t)!;
 
-    let entity: Entity;
-
-    /**
-     * Subscribe before reading worldEntity: world.onAdd triggers lazy
-     * registration so worldEntity is guaranteed to exist after this.
-     */
-    const onAddUnsub = world.onAdd(resolvedTag, (e) => {
-      if (e === entity) value = true;
+    const onAddUnsub = entity.onAdd(resolvedTag, () => {
+      value = true;
     });
 
-    const onRemoveUnsub = world.onRemove(resolvedTag, (e) => {
-      if (e === entity) value = false;
+    const onRemoveUnsub = entity.onRemove(resolvedTag, () => {
+      value = false;
     });
 
-    entity = getTargetEntity(t)!;
     value = entity.has(resolvedTag);
 
     return () => {

--- a/packages/svelte/src/hooks/use-target.svelte.ts
+++ b/packages/svelte/src/hooks/use-target.svelte.ts
@@ -1,14 +1,11 @@
 import { type Entity, type Relation, type Trait, type World } from '@koota/core';
 import { getTargetEntity } from '../utils/get-target-entity.js';
-import { isWorld } from '../utils/is-world.js';
 import { type MaybeGetter, resolve } from '../utils/resolve.js';
-import { useWorld } from '../world/world-context.js';
 
 export function useTarget<T extends Trait>(
   target: () => Entity | World | undefined | null,
   relation: MaybeGetter<Relation<T>>
 ): { readonly current: Entity | undefined } {
-  const contextWorld = useWorld();
   const initialEntity = getTargetEntity(target());
   let value = $state.raw<Entity | undefined>(initialEntity?.targetFor(resolve(relation)));
 
@@ -21,8 +18,7 @@ export function useTarget<T extends Trait>(
     }
 
     const resolvedRelation = resolve(relation);
-    const world = isWorld(t) ? t : contextWorld;
-    let entity: Entity;
+    const entity = getTargetEntity(t)!;
     let targets: Entity[];
 
     const update = () => {
@@ -30,17 +26,9 @@ export function useTarget<T extends Trait>(
       value = targets[0];
     };
 
-    /**
-     * Subscribe before reading worldEntity: world.onAdd triggers lazy
-     * registration so worldEntity is guaranteed to exist after this.
-     */
-    const onAddUnsub = world.onAdd(resolvedRelation, (e) => {
-      if (e === entity) update();
-    });
+    const onAddUnsub = entity.onAdd(resolvedRelation, update);
 
-    const onRemoveUnsub = world.onRemove(resolvedRelation, (e, removedTarget) => {
-      if (e !== entity) return;
-
+    const onRemoveUnsub = entity.onRemove(resolvedRelation, (_, removedTarget) => {
       // onRemove fires before core removes the target, so mirror its swap-and-pop.
       const index = targets.indexOf(removedTarget);
       if (index === -1) return;
@@ -50,11 +38,8 @@ export function useTarget<T extends Trait>(
       value = targets[0];
     });
 
-    const onChangeUnsub = world.onChange(resolvedRelation, (e) => {
-      if (e === entity) update();
-    });
+    const onChangeUnsub = entity.onChange(resolvedRelation, update);
 
-    entity = getTargetEntity(t)!;
     update();
 
     return () => {

--- a/packages/svelte/src/hooks/use-targets.svelte.ts
+++ b/packages/svelte/src/hooks/use-targets.svelte.ts
@@ -1,14 +1,11 @@
 import { type Entity, type Relation, type Trait, type World } from '@koota/core';
 import { getTargetEntity } from '../utils/get-target-entity.js';
-import { isWorld } from '../utils/is-world.js';
 import { type MaybeGetter, resolve } from '../utils/resolve.js';
-import { useWorld } from '../world/world-context.js';
 
 export function useTargets<T extends Trait>(
   target: () => Entity | World | undefined | null,
   relation: MaybeGetter<Relation<T>>
 ): { readonly current: Entity[] } {
-  const contextWorld = useWorld();
   const initialEntity = getTargetEntity(target());
   let value = $state.raw<Entity[]>(initialEntity?.targetsFor(resolve(relation)) ?? []);
 
@@ -21,8 +18,7 @@ export function useTargets<T extends Trait>(
     }
 
     const resolvedRelation = resolve(relation);
-    const world = isWorld(t) ? t : contextWorld;
-    let entity: Entity;
+    const entity = getTargetEntity(t)!;
 
     // Callbacks run inside whatever effect mutated the world, so they read
     // this plain list instead of the signal.
@@ -33,24 +29,19 @@ export function useTargets<T extends Trait>(
       value = next;
     };
 
-    /**
-     * Subscribe before reading worldEntity: world.onAdd triggers lazy
-     * registration so worldEntity is guaranteed to exist after this.
-     */
-    const onAddUnsub = world.onAdd(resolvedRelation, (e) => {
-      if (e === entity) update(entity.targetsFor(resolvedRelation));
+    const onAddUnsub = entity.onAdd(resolvedRelation, () => {
+      update(entity.targetsFor(resolvedRelation));
     });
 
     // onRemove fires before data is removed, so filter out the target
-    const onRemoveUnsub = world.onRemove(resolvedRelation, (e, removedTarget) => {
-      if (e === entity) update(targets.filter((p) => p !== removedTarget));
+    const onRemoveUnsub = entity.onRemove(resolvedRelation, (_, removedTarget) => {
+      update(targets.filter((p) => p !== removedTarget));
     });
 
-    const onChangeUnsub = world.onChange(resolvedRelation, (e) => {
-      if (e === entity) update(entity.targetsFor(resolvedRelation));
+    const onChangeUnsub = entity.onChange(resolvedRelation, () => {
+      update(entity.targetsFor(resolvedRelation));
     });
 
-    entity = getTargetEntity(t)!;
     update(entity.targetsFor(resolvedRelation));
 
     return () => {

--- a/packages/svelte/src/hooks/use-trait-effect.svelte.ts
+++ b/packages/svelte/src/hooks/use-trait-effect.svelte.ts
@@ -1,5 +1,4 @@
 import {
-  $internal as internal,
   type Entity,
   type RelationPair,
   type Trait,
@@ -7,42 +6,25 @@ import {
   type World,
 } from '@koota/core';
 import { untrack } from 'svelte';
-import { isWorld } from '../utils/is-world.js';
+import { getTargetEntity } from '../utils/get-target-entity.js';
 import { type MaybeGetter, resolve } from '../utils/resolve.js';
-import { useWorld } from '../world/world-context.js';
 
 export function useTraitEffect<T extends Trait>(
   target: () => Entity | World,
   trait: MaybeGetter<T | RelationPair<T>>,
   callback: (value: TraitRecord<T> | undefined) => void
 ) {
-  const contextWorld = useWorld();
   const notify = (value: TraitRecord<T> | undefined) => untrack(() => callback(value));
 
   $effect(() => {
     const t = target();
     const resolvedTrait = resolve(trait);
-    const world = isWorld(t) ? t : contextWorld;
+    const entity = getTargetEntity(t)!;
 
-    let entity: Entity;
+    const onChangeUnsub = entity.onChange(resolvedTrait, () => notify(entity.get(resolvedTrait)));
+    const onAddUnsub = entity.onAdd(resolvedTrait, () => notify(entity.get(resolvedTrait)));
+    const onRemoveUnsub = entity.onRemove(resolvedTrait, () => notify(undefined));
 
-    /**
-     * Subscribe before reading worldEntity: world.onChange triggers lazy
-     * registration so worldEntity is guaranteed to exist after this.
-     */
-    const onChangeUnsub = world.onChange(resolvedTrait, (e) => {
-      if (e === entity) notify(e.get(resolvedTrait));
-    });
-
-    const onAddUnsub = world.onAdd(resolvedTrait, (e) => {
-      if (e === entity) notify(e.get(resolvedTrait));
-    });
-
-    const onRemoveUnsub = world.onRemove(resolvedTrait, (e) => {
-      if (e === entity) notify(undefined);
-    });
-
-    entity = isWorld(t) ? t[internal].worldEntity : t;
     notify(entity.has(resolvedTrait) ? entity.get(resolvedTrait) : undefined);
 
     return () => {

--- a/packages/svelte/src/hooks/use-trait.svelte.ts
+++ b/packages/svelte/src/hooks/use-trait.svelte.ts
@@ -7,15 +7,12 @@ import {
 } from '@koota/core';
 import { untrack } from 'svelte';
 import { getTargetEntity } from '../utils/get-target-entity.js';
-import { isWorld } from '../utils/is-world.js';
 import { type MaybeGetter, resolve } from '../utils/resolve.js';
-import { useWorld } from '../world/world-context.js';
 
 export function useTrait<T extends Trait>(
   target: () => Entity | World | undefined | null,
   trait: MaybeGetter<T | RelationPair<T>>
 ): { readonly current: TraitRecord<T> | undefined } {
-  const contextWorld = useWorld();
   const initialEntity = getTargetEntity(target());
   const initialTrait = initialEntity === undefined ? undefined : resolve(trait);
   let value = $state.raw<TraitRecord<T> | undefined>(
@@ -36,29 +33,21 @@ export function useTrait<T extends Trait>(
     }
 
     const resolvedTrait = resolve(trait);
-    const world = isWorld(t) ? t : contextWorld;
-    let entity: Entity;
+    const entity = getTargetEntity(t)!;
 
-    /**
-     * Subscribe before reading worldEntity: world.onChange triggers lazy
-     * registration so worldEntity is guaranteed to exist after this.
-     */
-    const onChangeUnsub = world.onChange(resolvedTrait, (e) => {
-      if (e === entity) {
-        value = e.get(resolvedTrait);
-        untrack(() => version++);
-      }
+    const onChangeUnsub = entity.onChange(resolvedTrait, () => {
+      value = entity.get(resolvedTrait);
+      untrack(() => version++);
     });
 
-    const onAddUnsub = world.onAdd(resolvedTrait, (e) => {
-      if (e === entity) value = e.get(resolvedTrait);
+    const onAddUnsub = entity.onAdd(resolvedTrait, () => {
+      value = entity.get(resolvedTrait);
     });
 
-    const onRemoveUnsub = world.onRemove(resolvedTrait, (e) => {
-      if (e === entity) value = undefined;
+    const onRemoveUnsub = entity.onRemove(resolvedTrait, () => {
+      value = undefined;
     });
 
-    entity = getTargetEntity(t)!;
     value = entity.has(resolvedTrait) ? entity.get(resolvedTrait) : undefined;
 
     return () => {

--- a/packages/svelte/src/utils/get-target-entity.ts
+++ b/packages/svelte/src/utils/get-target-entity.ts
@@ -4,5 +4,7 @@ import { isWorld } from './is-world.js';
 export function getTargetEntity(target: Entity | World | undefined | null): Entity | undefined {
   if (target == null) return undefined;
   if (!isWorld(target)) return target;
-  return target.isRegistered ? target[internal].worldEntity : undefined;
+  // Adding no traits registers a lazy world so its entity exists.
+  if (!target.isRegistered) target.add();
+  return target[internal].worldEntity;
 }

--- a/skills/koota/references/runtime.md
+++ b/skills/koota/references/runtime.md
@@ -177,6 +177,14 @@ useEffect(() => {
 }, [world])
 ```
 
+The same hooks exist on entities and fire only for that entity. Prefer them when subscribing per entity (one per component, for example) since dispatch does not scale with the number of subscribers. The framework hooks use these internally.
+
+```typescript
+const unsub = entity.onChange(Position, (entity) => {
+  // Runs only when this entity's Position changes
+})
+```
+
 **Entity lifecycle events** fire on spawn/destroy (excludes the internal world entity):
 
 ```typescript


### PR DESCRIPTION
Following Flec's design I had avoided per-entity event subscriptions thinking it would cause too much friction. However, there is another cost on the other side. All of the framework hooks subscribe to a trait change and then need to filter per-entity themselves. This means that O(N^2) while now it is just O(N). With our more advanced benching I can see the tradeoffs, and it turned out the additional cost to this overhead was mostly in the cleanup phase. This was optimized mostly by being smarter about allocations and lookups. 

The new APIs are are accessed on the entity handle directly: `entity.onAdd()`, `entity.onRemove()` and `entity.onChange()`.