### PR TITLE
Low level page access with `getPages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ world.set(Time, { current: performance.now() })
 
 ### Select traits on queries for updates
 
-Query filters entity results and `select` is used to choose what traits are fetched for `updateEach` and `useStores`. This can be useful if your query is wider than the data you want to modify.
+Query filters entity results and `select` is used to choose what traits are fetched for `updateEach` and `getPages`. This can be useful if your query is wider than the data you want to modify.
 
 ```js
 // The query finds all entities with Position, Velocity and Mass
@@ -736,31 +736,26 @@ world.query(Position, Velocity, Mass)
 
 ### Modifying trait stores directly
 
-For performance-critical operations, you can modify trait stores directly using the `useStores` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. Stores are paged internally, so `useStores` gives you the raw paged stores plus a layout describing which query entities live in which pages and offsets.
+For performance-critical operations, `getPages()` returns cached page views with direct access to trait arrays. Each page contains a `stores` tuple in query or `select()` order, `indices` for the matching store offsets, and an `entities` array aligned with those indices. The returned array supports both `for...of` and indexed loops.
 
 ```js
-// Returns the raw stores plus a page-grouped query layout
-world.query(Position, Velocity).useStores(([position, velocity], layout) => {
-  // Loop over all the pages
-  for (let p = 0; p < layout.pageCount; p++) {
-    const pageId = layout.pageIds[p] // Physical page in the paged stores
-    const start = layout.pageStarts[p] // First flat query index in this page
-    const end = start + layout.pageCounts[p] // One past the last flat query index
+const pages = world.query(Position, Velocity).getPages()
 
-    const posX = position.x[pageId]
-    const posY = position.y[pageId]
-    const velX = velocity.x[pageId]
-    const velY = velocity.y[pageId]
-
-    // For each entity in the page, updates its data
-    for (let i = start; i < end; i++) {
-      const o = layout.offsets[i] // Offset within the current page
-      posX[o] += velX[o] * delta
-      posY[o] += velY[o] * delta
-    }
+for (const {
+  stores: [position, velocity],
+  indices,
+} of pages) {
+  for (let i = 0; i < indices.length; i++) {
+    const offset = indices[i]
+    position.x[offset] += velocity.x[offset] * delta
+    position.y[offset] += velocity.y[offset] * delta
   }
-})
+}
 ```
+
+`page.indices[i]` is the store offset for `page.entities[i]`. Use it to access values like `position.x[offset]` (SoA) or `objects[offset]` (AoS).
+
+Query each frame and finish the loop before adding or removing traits or entities. Direct writes don't notify subscribers. Call `entity.changed(Trait)` when you need notifications.
 
 ### Query tips for the curious
 
@@ -1091,7 +1086,7 @@ const Attacker = trait<Pick<AttackerSchema, keyof AttackerSchema>>({
 
 #### Accessing the store directly
 
-The store can be accessed with `getStore`, but this low-level access is risky as it bypasses Koota's guard rails. However, this can be useful for debugging where direct introspection of the store is needed. For direct store mutations, use the [`useStores` API](#modifying-trait-stores-direclty) instead.
+The store can be accessed with `getStore`, but this low-level access is risky as it bypasses Koota's guard rails. However, this can be useful for debugging where direct introspection of the store is needed. For direct store mutations, use the [`getPages` API](#modifying-trait-stores-directly) instead.
 
 ```js
 // Returns SoA or AoS depending on the trait

--- a/benches/n-body/n-body.bench.ts
+++ b/benches/n-body/n-body.bench.ts
@@ -1,0 +1,104 @@
+import { assert, bench, group } from '@pmndrs/labs';
+import { createWorld, trait, type World } from 'koota';
+import { mulberry32 } from 'math/random';
+
+const Position = trait({ x: 0, y: 0 });
+const Acceleration = trait({ x: 0, y: 0 });
+
+group('N-body 2k @n-body @pages', () => {
+  for (const run of [updateEach, getPages]) {
+    bench(run.name, function* () {
+      const world = createWorld();
+      const random = mulberry32.create(42);
+      for (let i = 0; i < 2000; i++) {
+        world.spawn(
+          Position({ x: mulberry32.sample(random) * 1000, y: mulberry32.sample(random) * 1000 }),
+          Acceleration
+        );
+        // Leave gaps to exercise sparse pages.
+        world.spawn();
+      }
+
+      const checksum = () => {
+        let x = 0;
+        let y = 0;
+        world.query(Acceleration).readEach(([acceleration], entity) => {
+          x += acceleration.x * (entity.id() + 1);
+          y += acceleration.y * (entity.id() + 1);
+        });
+        return [x, y];
+      };
+
+      updateEach(world);
+      const expected = checksum();
+      // Warm up the repeated frame work before measurement.
+      for (let i = 0; i < 20; i++) run(world);
+      world.query(Acceleration).updateEach(([acceleration]) => {
+        acceleration.x = 0;
+        acceleration.y = 0;
+      });
+
+      // Positions stay fixed and each pass overwrites acceleration.
+      yield {
+        bench: () => run(world),
+        snapshot: () => {
+          const actual = checksum();
+          assert.equal(actual, expected);
+          return actual;
+        },
+      };
+      world.destroy();
+    }).baseline(run === updateEach);
+  }
+});
+
+function updateEach(world: World) {
+  const sources = world.query(Position);
+  world.query(Position, Acceleration).updateEach(
+    ([position, acceleration]) => {
+      let x = 0;
+      let y = 0;
+      sources.readEach(([other]) => {
+        const dx = other.x - position.x;
+        const dy = other.y - position.y;
+        const inverseDistance = 1 / Math.sqrt(dx * dx + dy * dy + 1);
+        const force = inverseDistance * inverseDistance * inverseDistance;
+        x += dx * force;
+        y += dy * force;
+      });
+      acceleration.x = x;
+      acceleration.y = y;
+    },
+    { changeDetection: 'never' }
+  );
+}
+
+function getPages(world: World) {
+  const pages = world.query(Position, Acceleration).getPages();
+  for (const {
+    stores: [position, acceleration],
+    indices,
+  } of pages) {
+    for (let i = 0; i < indices.length; i++) {
+      const a = indices[i];
+      let x = 0;
+      let y = 0;
+      for (const {
+        stores: [other],
+        indices: otherIndices,
+      } of pages) {
+        for (let j = 0; j < otherIndices.length; j++) {
+          const b = otherIndices[j];
+          const dx = other.x[b] - position.x[a];
+          const dy = other.y[b] - position.y[a];
+          const inverseDistance = 1 / Math.sqrt(dx * dx + dy * dy + 1);
+          const force = inverseDistance * inverseDistance * inverseDistance;
+          x += dx * force;
+          y += dy * force;
+        }
+      }
+      acceleration.x[a] = x;
+      acceleration.y[a] = y;
+    }
+  }
+}

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -11,28 +11,26 @@ Performance, safety and readability are all tradeoffs. The standard patterns are
 
 ## Modifying trait stores directly
 
-For performance-critical operations, you can modify trait stores directly using the `useStores` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. Stores are paged internally, and `useStores` returns the raw stores plus a cached page-grouped layout so your loops can stay cache-friendly without manual page math.
+For performance-critical operations, `getPages()` returns cached page views with direct access to trait arrays. Each page contains a `stores` tuple in query or `select()` order, `indices` for the matching store offsets, and an `entities` array aligned with those indices. The returned array supports both `for...of` and indexed loops.
 
 ```js
-// Returns the raw stores plus a page-grouped query layout
-world.query(Position, Velocity).useStores(([position, velocity], layout) => {
-  for (let p = 0; p < layout.pageCount; p++) {
-    const pageId = layout.pageIds[p]
-    const start = layout.pageStarts[p]
-    const end = start + layout.pageCounts[p]
-    const posX = position.x[pageId]
-    const posY = position.y[pageId]
-    const velX = velocity.x[pageId]
-    const velY = velocity.y[pageId]
+const pages = world.query(Position, Velocity).getPages()
 
-    for (let i = start; i < end; i++) {
-      const o = layout.offsets[i]
-      posX[o] += velX[o] * delta
-      posY[o] += velY[o] * delta
-    }
+for (const {
+  stores: [position, velocity],
+  indices,
+} of pages) {
+  for (let i = 0; i < indices.length; i++) {
+    const offset = indices[i]
+    position.x[offset] += velocity.x[offset] * delta
+    position.y[offset] += velocity.y[offset] * delta
   }
-})
+}
 ```
+
+`page.indices[i]` is the store offset for `page.entities[i]`. Use it to access values like `position.x[offset]` (SoA) or `objects[offset]` (AoS).
+
+Query each frame and finish the loop before adding or removing traits or entities. Direct writes don't notify subscribers. Call `entity.changed(Trait)` when you need notifications.
 
 ## Query optimization
 

--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -55,7 +55,7 @@ entities.includes(entity) // This will always be false
 
 ## Select traits on queries for updates
 
-Query filters entity results and `select` is used to choose what traits are fetched for `updateEach` and `useStores`. This can be useful if your query is wider than the data you want to modify.
+Query filters entity results and `select` is used to choose what traits are fetched for `updateEach` and `getPages`. This can be useful if your query is wider than the data you want to modify.
 
 ```js
 // The query finds all entities with Position, Velocity and Mass
@@ -68,3 +68,7 @@ world.query(Position, Velocity, Mass)
     mass.value += 1
   });
 ```
+
+## Direct page access
+
+Use `query.getPages()` to iterate cached page views and read or write trait arrays directly. See [Modifying trait stores directly](../advanced/performance.md#modifying-trait-stores-directly) for the page shape, iteration pattern, and change notification behavior.

--- a/docs/api/trait.md
+++ b/docs/api/trait.md
@@ -170,7 +170,7 @@ const Attacker = trait<Pick<AttackerSchema, keyof AttackerSchema>>({
 
 ## Accessing the store directly
 
-The store can be accessed with `getStore`, but this low-level access is risky as it bypasses Koota's guard rails. However, this can be useful for debugging where direct introspection of the store is needed. For direct store mutations, use the [`useStores` API](#modifying-trait-stores-direclty) instead.
+The store can be accessed with `getStore`, but this low-level access is risky as it bypasses Koota's guard rails. However, this can be useful for debugging where direct introspection of the store is needed. For direct store mutations, use the [`getPages` API](../advanced/performance.md#modifying-trait-stores-directly) instead.
 
 ```js
 // Returns SoA or AoS depending on the trait

--- a/examples/add-remove/src/view/systems/syncThreeObjects.ts
+++ b/examples/add-remove/src/view/systems/syncThreeObjects.ts
@@ -18,48 +18,45 @@ export const syncThreeObjects = ({ world }: { world: World }) => {
   const colors = particles.geometry.attributes.color.array;
   const sizes = particles.geometry.attributes.size.array;
 
-  entities.useStores(([position, circle, color], layout) => {
-    const { pageCount, pageIds, pageStarts, pageCounts, offsets, entities } = layout;
+  for (const {
+    stores: [position, circle, color],
+    indices,
+    entities: pageEntities,
+  } of entities.getPages()) {
+    const posX = position.x;
+    const posY = position.y;
+    const posZ = position.z;
+    const radius = circle.radius;
+    const colorR = color.r;
+    const colorG = color.g;
+    const colorB = color.b;
 
-    for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
-      const pageId = pageIds[pageIndex];
-      const start = pageStarts[pageIndex];
-      const end = start + pageCounts[pageIndex];
-      const posX = position.x[pageId];
-      const posY = position.y[pageId];
-      const posZ = position.z[pageId];
-      const radius = circle.radius[pageId];
-      const colorR = color.r[pageId];
-      const colorG = color.g[pageId];
-      const colorB = color.b[pageId];
+    for (let i = 0; i < indices.length; i++) {
+      const eid = pageEntities[i].id();
+      const offset = indices[i];
 
-      for (let i = start; i < end; i++) {
-        const eid = entities[i].id();
-        const offset = offsets[i];
+      // Update positions
+      positions[eid * 3] = posX[offset];
+      positions[eid * 3 + 1] = posY[offset];
+      positions[eid * 3 + 2] = posZ[offset];
 
-        // Update positions
-        positions[eid * 3] = posX[offset];
-        positions[eid * 3 + 1] = posY[offset];
-        positions[eid * 3 + 2] = posZ[offset];
+      // Update sizes
+      sizes[eid] = radius[offset] * 0.3;
 
-        // Update sizes
-        sizes[eid] = radius[offset] * 0.3;
-
-        // Update colors
-        const r = normalize(colorR[offset], 0, 255);
-        const g = normalize(colorG[offset], 0, 255);
-        const b = normalize(colorB[offset], 0, 255);
-        colors[eid * 3] = r;
-        colors[eid * 3 + 1] = g;
-        colors[eid * 3 + 2] = b;
-      }
+      // Update colors
+      const r = normalize(colorR[offset], 0, 255);
+      const g = normalize(colorG[offset], 0, 255);
+      const b = normalize(colorB[offset], 0, 255);
+      colors[eid * 3] = r;
+      colors[eid * 3 + 1] = g;
+      colors[eid * 3 + 2] = b;
     }
+  }
 
-    for (let i = 0; i < removedEntities.length; i++) {
-      const eid = removedEntities[i].id();
-      sizes[eid] = 0;
-    }
-  });
+  for (let i = 0; i < removedEntities.length; i++) {
+    const eid = removedEntities[i].id();
+    sizes[eid] = 0;
+  }
 
   particles.geometry.attributes.position.needsUpdate = true;
   particles.geometry.attributes.color.needsUpdate = true;

--- a/examples/add-remove/src/view/trait/Points.ts
+++ b/examples/add-remove/src/view/trait/Points.ts
@@ -1,4 +1,4 @@
 import { trait } from 'koota';
 import type * as THREE from 'three';
 
-export const Points = trait({ object: null! as THREE.Points });
+export const Points = trait({ object: () => null! as THREE.Points });

--- a/examples/add-remove/tsconfig.json
+++ b/examples/add-remove/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@config/typescript/base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["src"]
 }

--- a/examples/n-body/src/sim/systems/updateGravity.ts
+++ b/examples/n-body/src/sim/systems/updateGravity.ts
@@ -4,66 +4,58 @@ import { Time } from '../traits/Time';
 import { bodyTraits } from './setInitial';
 
 export const updateGravity = ({ world }: { world: World }) => {
-  const bodies = world.query(...bodyTraits);
+  const pages = world.query(...bodyTraits).getPages();
   const { delta } = world.get(Time)!;
 
-  bodies.useStores(([position, velocity, mass, _, acceleration], layout) => {
-    const { pageCount, pageIds, pageStarts, pageCounts, offsets } = layout;
+  for (const currentPage of pages) {
+    const [position, velocity, mass, , acceleration] = currentPage.stores;
+    const currentPosX = position.x;
+    const currentPosY = position.y;
+    const currentVelX = velocity.x;
+    const currentVelY = velocity.y;
+    const currentMass = mass.value;
+    const currentAccX = acceleration.x;
+    const currentAccY = acceleration.y;
 
-    for (let currentPageIndex = 0; currentPageIndex < pageCount; currentPageIndex++) {
-      const currentPageId = pageIds[currentPageIndex];
-      const currentStart = pageStarts[currentPageIndex];
-      const currentEnd = currentStart + pageCounts[currentPageIndex];
-      const currentPosX = position.x[currentPageId];
-      const currentPosY = position.y[currentPageId];
-      const currentVelX = velocity.x[currentPageId];
-      const currentVelY = velocity.y[currentPageId];
-      const currentMass = mass.value[currentPageId];
-      const currentAccX = acceleration.x[currentPageId];
-      const currentAccY = acceleration.y[currentPageId];
+    for (let currentIndex = 0; currentIndex < currentPage.indices.length; currentIndex++) {
+      const currentOffset = currentPage.indices[currentIndex];
+      const currentX = currentPosX[currentOffset];
+      const currentY = currentPosY[currentOffset];
+      const bodyMass = +currentMass[currentOffset];
 
-      for (let currentIndex = currentStart; currentIndex < currentEnd; currentIndex++) {
-        const currentOffset = offsets[currentIndex];
-        const currentX = currentPosX[currentOffset];
-        const currentY = currentPosY[currentOffset];
-        const bodyMass = +currentMass[currentOffset];
+      currentAccX[currentOffset] = 0;
+      currentAccY[currentOffset] = 0;
 
-        currentAccX[currentOffset] = 0;
-        currentAccY[currentOffset] = 0;
+      for (const targetPage of pages) {
+        const [targetPosition, , targetBodyMass] = targetPage.stores;
+        const targetPosX = targetPosition.x;
+        const targetPosY = targetPosition.y;
+        const targetMass = targetBodyMass.value;
 
-        for (let targetPageIndex = 0; targetPageIndex < pageCount; targetPageIndex++) {
-          const targetPageId = pageIds[targetPageIndex];
-          const targetStart = pageStarts[targetPageIndex];
-          const targetEnd = targetStart + pageCounts[targetPageIndex];
-          const targetPosX = position.x[targetPageId];
-          const targetPosY = position.y[targetPageId];
-          const targetMass = mass.value[targetPageId];
+        for (let targetIndex = 0; targetIndex < targetPage.indices.length; targetIndex++) {
+          const targetOffset = targetPage.indices[targetIndex];
 
-          for (let targetIndex = targetStart; targetIndex < targetEnd; targetIndex++) {
-            const targetOffset = offsets[targetIndex];
-
-            if (currentPageId === targetPageId && currentOffset === targetOffset) {
-              continue;
-            }
-
-            const dx = targetPosX[targetOffset] - currentX;
-            const dy = targetPosY[targetOffset] - currentY;
-            let distanceSquared = dx * dx + dy * dy;
-
-            if (distanceSquared < CONSTANTS.STICKY) distanceSquared = CONSTANTS.STICKY;
-
-            const distance = Math.sqrt(distanceSquared);
-            const forceMagnitude = (bodyMass * +targetMass[targetOffset]) / distanceSquared;
-
-            currentAccX[currentOffset] += (dx / distance) * forceMagnitude;
-            currentAccY[currentOffset] += (dy / distance) * forceMagnitude;
+          if (currentPage === targetPage && currentOffset === targetOffset) {
+            continue;
           }
-        }
 
-        // Apply computed force to entity's velocity, adjusting for its mass
-        currentVelX[currentOffset] += (currentAccX[currentOffset] * delta) / bodyMass;
-        currentVelY[currentOffset] += (currentAccY[currentOffset] * delta) / bodyMass;
+          const dx = targetPosX[targetOffset] - currentX;
+          const dy = targetPosY[targetOffset] - currentY;
+          let distanceSquared = dx * dx + dy * dy;
+
+          if (distanceSquared < CONSTANTS.STICKY) distanceSquared = CONSTANTS.STICKY;
+
+          const distance = Math.sqrt(distanceSquared);
+          const forceMagnitude = (bodyMass * +targetMass[targetOffset]) / distanceSquared;
+
+          currentAccX[currentOffset] += (dx / distance) * forceMagnitude;
+          currentAccY[currentOffset] += (dy / distance) * forceMagnitude;
+        }
       }
+
+      // Apply computed force to entity's velocity, adjusting for its mass
+      currentVelX[currentOffset] += (currentAccX[currentOffset] * delta) / bodyMass;
+      currentVelY[currentOffset] += (currentAccY[currentOffset] * delta) / bodyMass;
     }
-  });
+  }
 };

--- a/examples/react-120/src/sim/systems/update-ball-collision.ts
+++ b/examples/react-120/src/sim/systems/update-ball-collision.ts
@@ -5,81 +5,75 @@ export function updateBallCollision(world: World) {
   const { delta } = world.get(Time)!;
   const invDelta = delta > 0 ? 1 / delta : 0;
 
-  world.query(Position, Velocity, Ball).useStores(([position, velocity, ball], layout) => {
-    const { pageCount, pageIds, pageStarts, pageCounts, offsets, entities } = layout;
+  const pages = world.query(Position, Velocity, Ball).getPages();
+  for (const pageA of pages) {
+    const [positionA, velocityA, ballA] = pageA.stores;
+    const aPosX = positionA.x;
+    const aPosY = positionA.y;
+    const aVelX = velocityA.x;
+    const aVelY = velocityA.y;
+    const aRadius = ballA.radius;
 
-    for (let aPageIndex = 0; aPageIndex < pageCount; aPageIndex++) {
-      const aPageId = pageIds[aPageIndex];
-      const aStart = pageStarts[aPageIndex];
-      const aEnd = aStart + pageCounts[aPageIndex];
-      const aPosX = position.x[aPageId];
-      const aPosY = position.y[aPageId];
-      const aVelX = velocity.x[aPageId];
-      const aVelY = velocity.y[aPageId];
-      const aRadius = ball.radius[aPageId];
+    for (let ai = 0; ai < pageA.indices.length; ai++) {
+      const offsetA = pageA.indices[ai];
+      const entityA = pageA.entities[ai];
 
-      for (let ai = aStart; ai < aEnd; ai++) {
-        const offsetA = offsets[ai];
-        const entityA = entities[ai];
+      const xA = aPosX[offsetA];
+      const yA = aPosY[offsetA];
+      const scaleA = entityA.get(Scale)?.value ?? 1;
+      const radiusA = aRadius[offsetA] * scaleA;
+      const massA = radiusA * radiusA * Math.PI;
 
-        const xA = aPosX[offsetA];
-        const yA = aPosY[offsetA];
-        const scaleA = entityA.get(Scale)?.value ?? 1;
-        const radiusA = aRadius[offsetA] * scaleA;
-        const massA = radiusA * radiusA * Math.PI;
+      for (let bPageIndex = pageA.index; bPageIndex < pages.length; bPageIndex++) {
+        const pageB = pages[bPageIndex];
+        const [positionB, velocityB, ballB] = pageB.stores;
+        const bStart = pageA === pageB ? ai + 1 : 0;
+        const bPosX = positionB.x;
+        const bPosY = positionB.y;
+        const bVelX = velocityB.x;
+        const bVelY = velocityB.y;
+        const bRadius = ballB.radius;
 
-        for (let bPageIndex = aPageIndex; bPageIndex < pageCount; bPageIndex++) {
-          const bPageId = pageIds[bPageIndex];
-          const bPageStart = pageStarts[bPageIndex];
-          const bEnd = bPageStart + pageCounts[bPageIndex];
-          const bStart = bPageIndex === aPageIndex ? ai + 1 : bPageStart;
-          const bPosX = position.x[bPageId];
-          const bPosY = position.y[bPageId];
-          const bVelX = velocity.x[bPageId];
-          const bVelY = velocity.y[bPageId];
-          const bRadius = ball.radius[bPageId];
+        for (let bi = bStart; bi < pageB.indices.length; bi++) {
+          const offsetB = pageB.indices[bi];
+          const entityB = pageB.entities[bi];
 
-          for (let bi = bStart; bi < bEnd; bi++) {
-            const offsetB = offsets[bi];
-            const entityB = entities[bi];
+          const xB = bPosX[offsetB];
+          const yB = bPosY[offsetB];
+          const scaleB = entityB.get(Scale)?.value ?? 1;
+          const radiusB = bRadius[offsetB] * scaleB;
 
-            const xB = bPosX[offsetB];
-            const yB = bPosY[offsetB];
-            const scaleB = entityB.get(Scale)?.value ?? 1;
-            const radiusB = bRadius[offsetB] * scaleB;
+          const rsum = radiusA + radiusB;
+          const dx = xA - xB;
+          const dy = yA - yB;
 
-            const rsum = radiusA + radiusB;
-            const dx = xA - xB;
-            const dy = yA - yB;
+          // AABB early-out
+          if (dx > rsum || -dx > rsum || dy > rsum || -dy > rsum) continue;
 
-            // AABB early-out
-            if (dx > rsum || -dx > rsum || dy > rsum || -dy > rsum) continue;
+          // Circle overlap check
+          const distSq = dx * dx + dy * dy;
+          if (distSq >= rsum * rsum) continue;
 
-            // Circle overlap check
-            const distSq = dx * dx + dy * dy;
-            if (distSq >= rsum * rsum) continue;
+          // Penetration along the center line (mirrors reference scaling by radius sum)
+          const dist = Math.sqrt(distSq) || 1;
+          const penetration = dist - rsum; // negative
+          const invNorm = 1 / rsum;
+          const offX = dx * penetration * invNorm;
+          const offY = dy * penetration * invNorm;
 
-            // Penetration along the center line (mirrors reference scaling by radius sum)
-            const dist = Math.sqrt(distSq) || 1;
-            const penetration = dist - rsum; // negative
-            const invNorm = 1 / rsum;
-            const offX = dx * penetration * invNorm;
-            const offY = dy * penetration * invNorm;
+          // Mass-based momentum distribution (πr²)
+          const massB = radiusB * radiusB * Math.PI;
+          const invTotal = 1 / (massA + massB);
+          const ratioA = massB * invTotal; // push A by proportion of B
+          const ratioB = massA * invTotal; // push B by proportion of A
 
-            // Mass-based momentum distribution (πr²)
-            const massB = radiusB * radiusB * Math.PI;
-            const invTotal = 1 / (massA + massB);
-            const ratioA = massB * invTotal; // push A by proportion of B
-            const ratioB = massA * invTotal; // push B by proportion of A
-
-            // Convert position-like offsets to per-second velocity impulses
-            aVelX[offsetA] -= offX * ratioA * invDelta;
-            aVelY[offsetA] -= offY * ratioA * invDelta;
-            bVelX[offsetB] += offX * ratioB * invDelta;
-            bVelY[offsetB] += offY * ratioB * invDelta;
-          }
+          // Convert position-like offsets to per-second velocity impulses
+          aVelX[offsetA] -= offX * ratioA * invDelta;
+          aVelY[offsetA] -= offY * ratioA * invDelta;
+          bVelX[offsetB] += offX * ratioB * invDelta;
+          bVelY[offsetB] += offY * ratioB * invDelta;
         }
       }
     }
-  });
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   IsNotModifier,
   Modifier,
   QueryLayout,
+  QueryPage,
   Query,
   QueryModifier,
   QueryParameter,
@@ -26,6 +27,7 @@ export type {
   QueryUnsubscriber,
   QueryHash,
   StoresFromParameters,
+  PageStoresFromParameters,
 } from './query/types';
 export { $queryRef } from './query/symbols';
 export { relation } from './relation/relation';

--- a/packages/core/src/query/query-pages.ts
+++ b/packages/core/src/query/query-pages.ts
@@ -1,0 +1,43 @@
+import type { Store } from '../storage';
+import type { QueryLayout, QueryPage } from './types';
+
+// Each layout can serve multiple query parameter orders and selections.
+const pageCaches = new WeakMap<QueryLayout, { stores: Store<any>[]; pages: QueryPage<any>[] }[]>();
+
+export function getQueryPages(stores: Store<any>[], layout: QueryLayout): QueryPage<any>[] {
+  if (layout.pageCount === 0) return [];
+
+  let cache = pageCaches.get(layout);
+  if (cache) {
+    for (const entry of cache) {
+      if (entry.stores.length !== stores.length) continue;
+      if (entry.stores.every((store, i) => store === stores[i])) return entry.pages;
+    }
+  } else {
+    cache = [];
+    pageCaches.set(layout, cache);
+  }
+
+  const pages: QueryPage<any>[] = [];
+  for (let p = 0; p < layout.pageCount; p++) {
+    const id = layout.pageIds[p];
+    const start = layout.pageStarts[p];
+    const end = start + layout.pageCounts[p];
+    const pageStores = stores.map((store) => {
+      // Materialize missing pages so later trait additions use the same arrays.
+      if (Array.isArray(store)) return (store[id] ??= []);
+      const page: Record<string, unknown[]> = {};
+      for (const key in store) page[key] = store[key][id] ??= [];
+      return page;
+    });
+    pages.push({
+      index: p,
+      stores: pageStores as QueryPage<any>['stores'],
+      indices: layout.offsets.subarray(start, end),
+      entities: layout.entities.slice(start, end),
+    });
+  }
+
+  cache.push({ stores: stores.slice(), pages });
+  return pages;
+}

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -3,9 +3,8 @@ import type { Entity } from '../entity/types';
 import { getEntityId } from '../entity/utils/pack-entity';
 import { isEntityAlive } from '../entity/utils/entity-index';
 import { isRelationPair } from '../relation/utils/is-relation';
-import type { Relation } from '../relation/types';
 import { Store } from '../storage';
-import { getStore } from '../trait/trait';
+import { registerTrait } from '../trait/trait';
 import type { Trait } from '../trait/types';
 import { shallowEqual } from '../utils/shallow-equal';
 import { hasSubscribers } from '../trait/subscriptions';
@@ -13,15 +12,16 @@ import { getTraitInstance } from '../trait/trait-instance';
 import type { WorldContext } from '../world';
 import { isModifier } from './modifier';
 import { setChanged } from './modifiers/changed';
+import { getQueryPages } from './query-pages';
 import type {
   InstancesFromParameters,
   QueryInstance,
   QueryLayout,
   QueryLayoutCache,
   QueryParameter,
+  QueryPage,
   QueryResult,
   QueryResultOptions,
-  StoresFromParameters,
 } from './types';
 
 export function createQueryResult<T extends QueryParameter[]>(
@@ -35,6 +35,8 @@ export function createQueryResult<T extends QueryParameter[]>(
 
   getQueryStores(params, traits, stores, ctx);
   let usesCustomOrder = false;
+  const version = query.version;
+  let layout: QueryLayout | undefined;
 
   const results = Object.assign(entities, {
     readEach(callback: (state: InstancesFromParameters<T>, entity: Entity, index: number) => void) {
@@ -164,12 +166,12 @@ export function createQueryResult<T extends QueryParameter[]>(
       return results;
     },
 
-    useStores(callback: (stores: StoresFromParameters<T>, layout: QueryLayout) => void) {
-      const layout = usesCustomOrder
-        ? createQueryLayout(entities)
-        : getCachedQueryLayout(query, entities);
-      callback(stores as unknown as StoresFromParameters<T>, layout);
-      return results;
+    getPages() {
+      layout ??=
+        usesCustomOrder || query.isTracking || query.version !== version
+          ? createQueryLayout(entities)
+          : getCachedQueryLayout(query, entities);
+      return getQueryPages(stores, layout) as QueryPage<T>[];
     },
 
     select<U extends QueryParameter[]>(...params: U): QueryResult<U> {
@@ -183,6 +185,7 @@ export function createQueryResult<T extends QueryParameter[]>(
       callback: (a: Entity, b: Entity) => number = (a, b) => getEntityId(a) - getEntityId(b)
     ): QueryResult<T> {
       usesCustomOrder = true;
+      layout = undefined;
       Array.prototype.sort.call(entities, callback);
       return results;
     },
@@ -248,32 +251,31 @@ export function createQueryResult<T extends QueryParameter[]>(
   for (let i = 0; i < params.length; i++) {
     const param = params[i];
 
-    if (isRelationPair(param)) {
-      const relation = param.relation as Relation<Trait>;
-      const baseTrait = relation[$internal].trait;
-      if (baseTrait[$internal].type !== 'tag') {
-        traits.push(baseTrait);
-        stores.push(getStore(ctx, baseTrait));
-      }
-      continue;
-    }
+    if (isRelationPair(param)) continue;
 
     if (isModifier(param)) {
       if (param.type === 'not') continue;
 
       const modifierTraits = param.traits;
       for (const trait of modifierTraits) {
-        if (trait[$internal].type === 'tag') continue;
+        if (trait[$internal].type === 'tag' || trait[$internal].relation) continue;
         traits.push(trait);
-        stores.push(getStore(ctx, trait));
+        stores.push(getQueryStore(ctx, trait));
       }
     } else {
       const trait = param as Trait;
       if (trait[$internal].type === 'tag') continue;
       traits.push(trait);
-      stores.push(getStore(ctx, trait));
+      stores.push(getQueryStore(ctx, trait));
     }
   }
+}
+
+function getQueryStore(ctx: WorldContext, trait: Trait): Store<any> {
+  const instance = getTraitInstance(ctx.traitInstances, trait);
+  if (instance) return instance.store;
+  registerTrait(ctx, trait);
+  return getTraitInstance(ctx.traitInstances, trait)!.store;
 }
 
 type QueryPageBuilder = {
@@ -371,15 +373,23 @@ export function createEmptyQueryResult(): QueryResult<QueryParameter[]> {
   const results = Object.assign([], {
     readEach: () => results,
     updateEach: () => results,
-    useStores: (callback: any) => {
-      callback([], EMPTY_LAYOUT_CACHE);
-      return results;
-    },
+    getPages: () => [],
     select: () => results,
     sort: () => results,
   }) as QueryResult<QueryParameter[]>;
 
   return results;
+}
+
+const relationOnlyLayouts = new WeakMap<QueryResult<any>, QueryLayout>();
+
+function getRelationOnlyLayout(results: QueryResult<any>) {
+  let layout = relationOnlyLayouts.get(results);
+  if (!layout) {
+    layout = createQueryLayout(results);
+    relationOnlyLayouts.set(results, layout);
+  }
+  return layout;
 }
 
 // Shared methods for relation-only query snapshots.
@@ -396,9 +406,8 @@ const relationOnlyMethods = {
     }
     return this;
   },
-  useStores(this: QueryResult<any>, callback: any) {
-    callback([], createQueryLayout(this as unknown as Entity[]));
-    return this;
+  getPages(this: QueryResult<any>) {
+    return getQueryPages([], getRelationOnlyLayout(this));
   },
   select(this: QueryResult<any>) {
     return this;
@@ -408,6 +417,7 @@ const relationOnlyMethods = {
     callback: (a: Entity, b: Entity) => number = (a, b) => getEntityId(a) - getEntityId(b)
   ) {
     Array.prototype.sort.call(this, callback);
+    relationOnlyLayouts.delete(this);
     return this;
   },
 };

--- a/packages/core/src/query/types.ts
+++ b/packages/core/src/query/types.ts
@@ -38,6 +38,15 @@ export type QueryLayoutCache = Omit<QueryLayout, 'entities'> & {
   entities: readonly Entity[];
 };
 
+export type QueryPage<T extends QueryParameter[] = QueryParameter[]> = {
+  /** Page ordinal in this query result */
+  readonly index: number;
+  readonly stores: PageStoresFromParameters<T>;
+  /** Store offsets for the matching entities in this page */
+  readonly indices: Uint16Array;
+  readonly entities: readonly Entity[];
+};
+
 export type QueryResult<T extends QueryParameter[] = QueryParameter[]> = readonly Entity[] & {
   readEach: (
     callback: (state: InstancesFromParameters<T>, entity: Entity, index: number) => void
@@ -46,9 +55,8 @@ export type QueryResult<T extends QueryParameter[] = QueryParameter[]> = readonl
     callback: (state: InstancesFromParameters<T>, entity: Entity, index: number) => void,
     options?: QueryResultOptions
   ) => QueryResult<T>;
-  useStores: (
-    callback: (stores: StoresFromParameters<T>, layout: QueryLayout) => void
-  ) => QueryResult<T>;
+  /** Returns cached page views with direct access to trait data, without change detection */
+  getPages: () => readonly QueryPage<T>[];
   select<U extends QueryParameter[]>(...params: U): QueryResult<U>;
   sort(callback?: (a: Entity, b: Entity) => number): QueryResult<T>;
 };
@@ -58,13 +66,27 @@ type UnwrapModifierData<T> = T extends Modifier<infer C> ? C : never;
 export type StoresFromParameters<T extends QueryParameter[]> = T extends [infer First, ...infer Rest]
   ? [
       ...(First extends Trait
-        ? [ExtractStore<First>]
+        ? IsTag<First> extends true
+          ? []
+          : [ExtractStore<First>]
         : First extends Modifier
-          ? StoresFromParameters<UnwrapModifierData<First>>
+          ? IsNotModifier<First> extends true
+            ? []
+            : StoresFromParameters<UnwrapModifierData<First>>
           : []),
       ...(Rest extends QueryParameter[] ? StoresFromParameters<Rest> : []),
     ]
   : [];
+
+type PageStores<T extends unknown[]> = {
+  [K in keyof T]: T[K] extends unknown[][]
+    ? T[K][number]
+    : { [P in keyof T[K]]: T[K][P] extends unknown[] ? T[K][P][number] : never };
+};
+
+export type PageStoresFromParameters<T extends QueryParameter[]> = PageStores<
+  StoresFromParameters<T>
+>;
 
 export type InstancesFromParameters<T extends QueryParameter[]> = T extends [
   infer First,

--- a/packages/core/tests/pages.test.ts
+++ b/packages/core/tests/pages.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { createWorld, Not, relation, trait } from '../src';
+
+describe('Query pages', () => {
+  let world: ReturnType<typeof createWorld>;
+
+  beforeEach(() => {
+    world = createWorld();
+  });
+
+  afterEach(() => {
+    world.destroy();
+  });
+
+  it('reads and writes matching entities across sparse pages without emitting changes', () => {
+    const Position = trait({ x: 0 });
+    const Velocity = trait({ x: 2 });
+    const entities = Array.from({ length: 2050 }, (_, i) =>
+      i % 3 === 0 ? world.spawn(Position({ x: i }), Velocity) : world.spawn()
+    ).filter((entity) => entity.has(Position));
+    const changed = vi.fn();
+    world.onChange(Position, changed);
+
+    const pages = world.query(Position, Velocity).getPages();
+    const visited = [];
+    for (const {
+      stores: [position, velocity],
+      indices,
+      entities,
+    } of pages) {
+      for (let i = 0; i < indices.length; i++) {
+        const offset = indices[i];
+        position.x[offset] += velocity.x[offset];
+        visited.push(entities[i]);
+      }
+    }
+
+    expect(pages.length).toBeGreaterThan(1);
+    expect(visited).toEqual(entities);
+    expect(entities.map((entity) => entity.get(Position)!.x)).toEqual(
+      entities.map((_, i) => i * 3 + 2)
+    );
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it('keeps caller and selection order while excluding tags, Not, and relation filters', () => {
+    const Position = trait({ x: 1 });
+    const Name = trait({ value: 'ball' });
+    const Active = trait();
+    const Hidden = trait();
+    const ChildOf = relation({ store: { weight: 1 } });
+    const parent = world.spawn();
+    world.spawn(Position, Name, Active, ChildOf(parent));
+
+    const query = world.query(Active, Position, Not(Hidden), ChildOf(parent), Name);
+    const { stores, indices } = query.getPages()[0];
+    expectTypeOf(stores).toEqualTypeOf<[{ x: number[] }, { value: string[] }]>();
+    expect(stores).toHaveLength(2);
+    expect([stores[0].x[indices[0]], stores[1].value[indices[0]]]).toEqual([1, 'ball']);
+    expect(query.select(Name, Position).getPages()[0].stores).toEqual([stores[1], stores[0]]);
+  });
+
+  it('writes AoS values directly through the instance array', () => {
+    const Ref = trait(() => ({ value: 1 }));
+    const entity = world.spawn(Ref);
+    const {
+      stores: [refs],
+      indices,
+    } = world.query(Ref).getPages()[0];
+    expectTypeOf(refs).toEqualTypeOf<{ value: number }[]>();
+
+    refs[indices[0]] = { value: 4 };
+    expect(entity.get(Ref)).toEqual({ value: 4 });
+  });
+
+  it('reuses pages for data changes and refreshes membership when queried again', () => {
+    const Position = trait({ x: 1 });
+    const first = world.spawn(Position);
+    const pages = world.query(Position).getPages();
+
+    first.set(Position, { x: 5 });
+    expect(world.query(Position).getPages()).toBe(pages);
+    expect(pages[0].stores[0].x[pages[0].indices[0]]).toBe(5);
+
+    const second = world.spawn(Position);
+    expect(world.query(Position).getPages()[0].entities).toEqual([first, second]);
+    first.remove(Position);
+    expect(world.query(Position).getPages()[0].entities).toEqual([second]);
+    second.destroy();
+    expect(world.query(Position).getPages()).toEqual([]);
+  });
+});

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -179,41 +179,6 @@ describe('Query', () => {
     expect(results[2]).toEqual({ x: 2, name: 'Entity2', index: 2 });
   });
 
-  it('useStores groups entities into query pages', () => {
-    const localWorld = createWorld();
-
-    // Pages are 1024 entities wide
-    for (let i = 0; i < 1026; i++) {
-      localWorld.spawn(Position({ x: i, y: i * 2 }));
-    }
-
-    const query = localWorld.query(Position);
-
-    query.useStores(([position], layout) => {
-      expect(layout.pageCount).toBe(2);
-
-      const firstEntityId = layout.entities[0].id();
-      const firstPageId = layout.pageIds[0];
-      const secondPageId = layout.pageIds[1];
-
-      expect(layout.pageCounts[0]).toBe(1023);
-      expect(layout.offsets[0]).toBe(firstEntityId & 1023);
-      expect(layout.entities[0].id()).toBe(firstEntityId);
-      expect(position.x[firstPageId][layout.offsets[1]]).toBe(1);
-
-      expect(layout.pageCounts[1]).toBe(3);
-      expect(Array.from(layout.offsets.slice(layout.pageStarts[1]))).toEqual([0, 1, 2]);
-      expect(layout.entities.slice(layout.pageStarts[1]).map((entity) => entity.id())).toEqual([
-        firstEntityId + 1023,
-        firstEntityId + 1024,
-        firstEntityId + 1025,
-      ]);
-      expect(position.x[secondPageId][layout.offsets[layout.pageStarts[1] + 2]]).toBe(1025);
-    });
-
-    localWorld.destroy();
-  });
-
   it('updateEach should return values in caller parameter order regardless of cache', () => {
     // Create entity with both traits
     world.spawn(Position({ x: 10, y: 20 }), Name({ name: 'test' }));

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -705,7 +705,7 @@ world.set(Time, { current: performance.now() })
 
 ### Select traits on queries for updates
 
-Query filters entity results and `select` is used to choose what traits are fetched for `updateEach` and `useStores`. This can be useful if your query is wider than the data you want to modify.
+Query filters entity results and `select` is used to choose what traits are fetched for `updateEach` and `getPages`. This can be useful if your query is wider than the data you want to modify.
 
 ```js
 // The query finds all entities with Position, Velocity and Mass
@@ -721,31 +721,26 @@ world.query(Position, Velocity, Mass)
 
 ### Modifying trait stores directly
 
-For performance-critical operations, you can modify trait stores directly using the `useStores` hook. This approach bypasses some of the safety checks and event triggers, so use it with caution. Stores are paged internally, so `useStores` gives you the raw paged stores plus a layout describing which query entities live in which pages and offsets.
+For performance-critical operations, `getPages()` returns cached page views with direct access to trait arrays. Each page contains a `stores` tuple in query or `select()` order, `indices` for the matching store offsets, and an `entities` array aligned with those indices. The returned array supports both `for...of` and indexed loops.
 
 ```js
-// Returns the raw stores plus a page-grouped query layout
-world.query(Position, Velocity).useStores(([position, velocity], layout) => {
-  // Loop over all the pages
-  for (let p = 0; p < layout.pageCount; p++) {
-    const pageId = layout.pageIds[p] // Physical page in the paged stores
-    const start = layout.pageStarts[p] // First flat query index in this page
-    const end = start + layout.pageCounts[p] // One past the last flat query index
+const pages = world.query(Position, Velocity).getPages()
 
-    const posX = position.x[pageId]
-    const posY = position.y[pageId]
-    const velX = velocity.x[pageId]
-    const velY = velocity.y[pageId]
-
-    // For each entity in the page, updates its data
-    for (let i = start; i < end; i++) {
-      const o = layout.offsets[i] // Offset within the current page
-      posX[o] += velX[o] * delta
-      posY[o] += velY[o] * delta
-    }
+for (const {
+  stores: [position, velocity],
+  indices,
+} of pages) {
+  for (let i = 0; i < indices.length; i++) {
+    const offset = indices[i]
+    position.x[offset] += velocity.x[offset] * delta
+    position.y[offset] += velocity.y[offset] * delta
   }
-})
+}
 ```
+
+`page.indices[i]` is the store offset for `page.entities[i]`. Use it to access values like `position.x[offset]` (SoA) or `objects[offset]` (AoS).
+
+Query each frame and finish the loop before adding or removing traits or entities. Direct writes don't notify subscribers. Call `entity.changed(Trait)` when you need notifications.
 
 ### Query tips for the curious
 
@@ -1076,7 +1071,7 @@ const Attacker = trait<Pick<AttackerSchema, keyof AttackerSchema>>({
 
 #### Accessing the store directly
 
-The store can be accessed with `getStore`, but this low-level access is risky as it bypasses Koota's guard rails. However, this can be useful for debugging where direct introspection of the store is needed. For direct store mutations, use the [`useStores` API](#modifying-trait-stores-direclty) instead.
+The store can be accessed with `getStore`, but this low-level access is risky as it bypasses Koota's guard rails. However, this can be useful for debugging where direct introspection of the store is needed. For direct store mutations, use the [`getPages` API](#modifying-trait-stores-directly) instead.
 
 ```js
 // Returns SoA or AoS depending on the trait

--- a/skills/koota/references/queries.md
+++ b/skills/koota/references/queries.md
@@ -10,7 +10,7 @@ Complete guide to querying entities in Koota.
 - [Caching queries](#caching-queries) - createQuery for performance
 - [Change detection](#change-detection) - updateEach options
 - [Query + select](#query--select) - Select subset of traits for updates
-- [Direct store access](#direct-store-access) - useStores for performance
+- [Direct store access](#direct-store-access) - getPages for performance
 
 ## Basic queries
 
@@ -233,36 +233,23 @@ world
 
 ## Direct store access
 
-For maximum performance, access the raw stores with a cached page-grouped layout. Stores are paged internally, so the layout tells you which query entities belong to which store page and offset:
+For performance-critical operations, `getPages()` returns cached page views with direct access to trait arrays. Each page contains a `stores` tuple in query or `select()` order, `indices` for the matching store offsets, and an `entities` array aligned with those indices. The returned array supports both `for...of` and indexed loops.
 
 ```typescript
-world.query(Position, Velocity).useStores(([position, velocity], layout) => {
-  for (let p = 0; p < layout.pageCount; p++) {
-    const pageId = layout.pageIds[p] // Physical page in the paged stores
-    const start = layout.pageStarts[p] // First flat query index in this page
-    const end = start + layout.pageCounts[p] // One past the last flat query index
-    const posX = position.x[pageId]
-    const posY = position.y[pageId]
-    const velX = velocity.x[pageId]
-    const velY = velocity.y[pageId]
+const pages = world.query(Position, Velocity).getPages()
 
-    for (let i = start; i < end; i++) {
-      const o = layout.offsets[i] // Offset within the current page
-      posX[o] += velX[o] * delta
-      posY[o] += velY[o] * delta
-    }
+for (const {
+  stores: [position, velocity],
+  indices,
+} of pages) {
+  for (let i = 0; i < indices.length; i++) {
+    const offset = indices[i]
+    position.x[offset] += velocity.x[offset] * delta
+    position.y[offset] += velocity.y[offset] * delta
   }
-})
+}
 ```
 
-**When to use:**
+`page.indices[i]` is the store offset for `page.entities[i]`. Use it to access values like `position.x[offset]` (SoA) or `objects[offset]` (AoS).
 
-- Updating thousands of entities per frame
-- SIMD-style operations
-- When profiling shows `updateEach` as bottleneck
-
-**Tradeoffs:**
-
-- Bypasses safety checks
-- No automatic change detection
-- More verbose code
+Query each frame and finish the loop before adding or removing traits or entities. Direct writes don't notify subscribers. Call `entity.changed(Trait)` when you need notifications.


### PR DESCRIPTION
Replaces `query.useStores()` with `query.getPages()`, returning cached page views that support ordinary loops. Each page exposes a typed stores tuple, matching store offsets, and aligned entities. This improves ergonomics and performance a bit, but also just aligns concepts.

```js
const pages = world.query(Position, Velocity).getPages();

for (const { stores: [position, velocity], indices } of pages) {
  for (const offset of indices) {
    position.x[offset] += velocity.x[offset];
    position.y[offset] += velocity.y[offset];
  }
}

console.log(entity.get(Position)); // { x: 1, y: 2 }
```