### PR TITLE
🐛 core: fix query hash collisions from the shared sort buffer

### DIFF
--- a/benches/query-performance/query-api.bench.ts
+++ b/benches/query-performance/query-api.bench.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { bench, group } from '@pmndrs/labs';
+import { createQuery, createWorld, relation, trait } from 'koota';
+
+const Position = trait({ x: 0, y: 0, z: 0 });
+const Velocity = trait({ x: 0, y: 0, z: 0 });
+const Health = trait({ hp: 100 });
+const IsPlayer = trait();
+const IsActive = trait();
+const ChildOf = relation();
+
+// Warm the cache before measurement. Relation filters are constructed in the timed
+// calls, with a trait before each filter to exercise recursive hashing.
+group('createQuery cache hit @query @query-api', () => {
+  bench('3 traits', function* () {
+    const expected = createQuery(Position, Velocity, Health);
+
+    yield () => createQuery(Position, Velocity, Health);
+
+    assert.equal(createQuery(Position, Velocity, Health), expected);
+  });
+
+  bench('relation target filter', function* () {
+    const expected = createQuery(Position, ChildOf(IsPlayer));
+    assert.notEqual(createQuery(Velocity, ChildOf(IsPlayer)), expected);
+
+    yield () => createQuery(Position, ChildOf(IsPlayer));
+
+    assert.equal(createQuery(Position, ChildOf(IsPlayer)), expected);
+  });
+
+  bench('nested relation target filter', function* () {
+    const expected = createQuery(Position, ChildOf(IsPlayer, ChildOf(IsActive)));
+    assert.notEqual(createQuery(Velocity, ChildOf(IsPlayer, ChildOf(IsActive))), expected);
+
+    yield () => createQuery(Position, ChildOf(IsPlayer, ChildOf(IsActive)));
+
+    assert.equal(createQuery(Position, ChildOf(IsPlayer, ChildOf(IsActive))), expected);
+  });
+});
+
+function setupWorld() {
+  const world = createWorld();
+  const grandparent = world.spawn(IsActive);
+  const parent = world.spawn(IsPlayer, ChildOf(grandparent));
+  const entity = world.spawn(Position, Velocity, Health, ChildOf(parent));
+  // A nonmatching sibling makes loss of the leading trait observable.
+  world.spawn(ChildOf(parent));
+  return { world, entity };
+}
+
+// One matching entity keeps result materialization small and constant while
+// measuring the public inline query path, including hashing and the cache lookup.
+group('world.query inline cache hit @query @query-api', () => {
+  bench('3 traits', function* () {
+    const { world, entity } = setupWorld();
+    assert.deepEqual(Array.from(world.query(Position, Velocity, Health)), [entity]);
+
+    yield () => world.query(Position, Velocity, Health);
+
+    assert.deepEqual(Array.from(world.query(Position, Velocity, Health)), [entity]);
+    world.destroy();
+  });
+
+  bench('relation target filter', function* () {
+    const { world, entity } = setupWorld();
+    assert.deepEqual(Array.from(world.query(IsActive, ChildOf(IsPlayer))), []);
+    assert.deepEqual(Array.from(world.query(Position, ChildOf(IsPlayer))), [entity]);
+
+    yield () => world.query(Position, ChildOf(IsPlayer));
+
+    assert.deepEqual(Array.from(world.query(Position, ChildOf(IsPlayer))), [entity]);
+    world.destroy();
+  });
+
+  bench('nested relation target filter', function* () {
+    const { world, entity } = setupWorld();
+    assert.deepEqual(Array.from(world.query(IsActive, ChildOf(IsPlayer, ChildOf(IsActive)))), []);
+    assert.deepEqual(Array.from(world.query(Position, ChildOf(IsPlayer, ChildOf(IsActive)))), [
+      entity,
+    ]);
+
+    yield () => world.query(Position, ChildOf(IsPlayer, ChildOf(IsActive)));
+
+    assert.deepEqual(Array.from(world.query(Position, ChildOf(IsPlayer, ChildOf(IsActive)))), [
+      entity,
+    ]);
+    world.destroy();
+  });
+});

--- a/packages/core/src/query/utils/create-query-hash.ts
+++ b/packages/core/src/query/utils/create-query-hash.ts
@@ -14,6 +14,10 @@ const RELATION_QUERY_OFFSET = 9000000;
 
 // Reusable buffer — avoids allocation per call.
 const sortBuf = new Float64Array(1024);
+// Where the current call starts writing. A relation filter given as inline parameters
+// recurses into createQueryHash, so the nested call has to claim the slice after the
+// entries its caller has already written instead of starting over at 0.
+let sortBufBase = 0;
 
 // Maps a sub-query hash string to a stable numeric id for encoding in the Float64Array.
 let nextQueryId = 1;
@@ -29,7 +33,8 @@ function queryHashNumericId(hash: string): number {
 }
 
 export const createQueryHash = (parameters: QueryParameter[]): QueryHash => {
-  let cursor = 0;
+  const base = sortBufBase;
+  let cursor = base;
 
   for (let i = 0; i < parameters.length; i++) {
     const param = parameters[i];
@@ -38,9 +43,14 @@ export const createQueryHash = (parameters: QueryParameter[]): QueryHash => {
       const relationId = (param.relation as Relation<Trait>)[$internal].trait.id;
 
       if (param.targetQuery) {
-        const subHash = isQuery(param.targetQuery)
-          ? param.targetQuery.hash
-          : createQueryHash([...param.targetQuery]);
+        let subHash: string;
+        if (isQuery(param.targetQuery)) {
+          subHash = param.targetQuery.hash;
+        } else {
+          sortBufBase = cursor;
+          subHash = createQueryHash([...param.targetQuery]);
+          sortBufBase = base;
+        }
         sortBuf[cursor++] =
           relationId * RELATION_FACTOR + queryHashNumericId(subHash) + RELATION_QUERY_OFFSET;
         continue;
@@ -62,7 +72,7 @@ export const createQueryHash = (parameters: QueryParameter[]): QueryHash => {
     sortBuf[cursor++] = (param as Trait).id;
   }
 
-  const filled = sortBuf.subarray(0, cursor);
+  const filled = sortBuf.subarray(base, cursor);
   filled.sort();
   return filled.join(',');
 };

--- a/packages/core/src/query/utils/create-query-hash.ts
+++ b/packages/core/src/query/utils/create-query-hash.ts
@@ -14,10 +14,6 @@ const RELATION_QUERY_OFFSET = 9000000;
 
 // Reusable buffer — avoids allocation per call.
 const sortBuf = new Float64Array(1024);
-// Where the current call starts writing. A relation filter given as inline parameters
-// recurses into createQueryHash, so the nested call has to claim the slice after the
-// entries its caller has already written instead of starting over at 0.
-let sortBufBase = 0;
 
 // Maps a sub-query hash string to a stable numeric id for encoding in the Float64Array.
 let nextQueryId = 1;
@@ -32,8 +28,7 @@ function queryHashNumericId(hash: string): number {
   return id;
 }
 
-export const createQueryHash = (parameters: QueryParameter[]): QueryHash => {
-  const base = sortBufBase;
+export const createQueryHash = (parameters: QueryParameter[], base = 0): QueryHash => {
   let cursor = base;
 
   for (let i = 0; i < parameters.length; i++) {
@@ -43,14 +38,10 @@ export const createQueryHash = (parameters: QueryParameter[]): QueryHash => {
       const relationId = (param.relation as Relation<Trait>)[$internal].trait.id;
 
       if (param.targetQuery) {
-        let subHash: string;
-        if (isQuery(param.targetQuery)) {
-          subHash = param.targetQuery.hash;
-        } else {
-          sortBufBase = cursor;
-          subHash = createQueryHash([...param.targetQuery]);
-          sortBufBase = base;
-        }
+        // Hash inline filters after the entries already written by this query.
+        const subHash = isQuery(param.targetQuery)
+          ? param.targetQuery.hash
+          : createQueryHash([...param.targetQuery], cursor);
         sortBuf[cursor++] =
           relationId * RELATION_FACTOR + queryHashNumericId(subHash) + RELATION_QUERY_OFFSET;
         continue;

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -261,6 +261,22 @@ describe('Query', () => {
     expect(onRemove).toHaveBeenCalledWith(child);
   });
 
+  it('keeps queries distinct when they share a relation filter', () => {
+    const parent = world.spawn(IsPlayer, IsActive);
+    const positioned = world.spawn(Position, ChildOf(parent));
+    const named = world.spawn(Name, ChildOf(parent));
+
+    // Parameters listed before a relation filter have to survive into the query hash,
+    // otherwise these two queries share a cache entry and the second returns the first's
+    // entities.
+    expect(Array.from(world.query(Position, ChildOf(IsPlayer)))).toEqual([positioned]);
+    expect(Array.from(world.query(Name, ChildOf(IsPlayer)))).toEqual([named]);
+
+    // The same holds when the filter itself takes several parameters.
+    expect(Array.from(world.query(Position, ChildOf(IsPlayer, IsActive)))).toEqual([positioned]);
+    expect(Array.from(world.query(Name, ChildOf(IsPlayer, IsActive)))).toEqual([named]);
+  });
+
   it('should select traits', () => {
     world.spawn(Position, Name);
 


### PR DESCRIPTION
Two queries that differ only in the traits listed *before* a relation filter end up with the same hash, so the second one reuses the first one's cached query instance and hands back the wrong entities.

### The problem

```js
const ChildOf = relation()

const parent = world.spawn(IsPlayer)
const positioned = world.spawn(Position, ChildOf(parent))
const named = world.spawn(Name, ChildOf(parent))

world.query(Position, ChildOf(IsPlayer)) // [positioned], correct
world.query(Name, ChildOf(IsPlayer))     // [positioned], should be [named]
```

Both of those hash to `3,49000001`, where `3` is `IsPlayer`'s trait id. Nothing throws, the second query just quietly returns the first one's results.

### The cause

`createQueryHash` in `packages/core/src/query/utils/create-query-hash.ts` fills a module level `Float64Array` called `sortBuf` and starts every call at index 0. When a relation filter is given as inline parameters, line 43 recurses into `createQueryHash` to hash the target query. That nested call restarts at index 0, so it writes `IsPlayer`'s id over the `Position` or `Name` id its caller had already put there, and sorts that slice on the way out. The caller then carries on from its own cursor and joins a buffer whose leading entries belong to the target query rather than to itself.

The hash is the cache key for `ctx.queriesHashMap` in `packages/core/src/world/world.ts` and for `universe.cachedQueries` in `packages/core/src/query/query.ts`, so a collision returns a query instance that was built from different parameters.

Passing a cached query instead, as in `ChildOf(createQuery(IsPlayer))`, was never affected, because that branch reads `.hash` off the query rather than recursing. That is also why the existing relation filter tests pass: they only ever pass the filter as the sole parameter, or pass a cached query.

### The fix

A nested call now claims the slice after its caller's entries through a `sortBufBase` offset, and every call joins `sortBuf.subarray(base, cursor)` rather than `subarray(0, cursor)`. Nothing extra is allocated, and a query with no inline relation filter never reads or writes the offset, so the hot path is unchanged.

### Verification

Node 24.11.0, pnpm 11.9.0.

`pnpm -F @koota/core test run` with the new test and without the source change fails on `expected [ 2 ] to deeply equal [ 3 ]`. With the source change the core suite is 136 passed, 1 expected fail, 8 files, and the whole `pnpm test` run is green across `@koota/collections` (23), `@koota/core` (136) and `@koota/react` (36).

I also ran the `pnpm test:build` path, building the bundle and running the generated tests against `dist`: 172 passed, 2 expected fail, 13 files. Reverting only `create-query-hash.ts` and rebuilding makes the same generated test fail, so the fix holds through the inline function transform too.
