### PR TITLE
Fix trait changes missed before React subscriptions attach

### DIFF
--- a/packages/core/src/query/modifiers/changed.ts
+++ b/packages/core/src/query/modifiers/changed.ts
@@ -38,6 +38,7 @@ function markChanged(ctx: WorldContext, entity: Entity, trait: Trait) {
 
   if (!hasTraitInstance(ctx.traitInstances, trait)) registerTrait(ctx, trait);
   const data = getTraitInstance(ctx.traitInstances, trait)!;
+  data.version++;
 
   const eid = getEntityId(entity);
   const { generationId, bitflag } = data;

--- a/packages/core/src/query/query-result.ts
+++ b/packages/core/src/query/query-result.ts
@@ -60,6 +60,13 @@ export function createQueryResult<T extends QueryParameter[]>(
     ) {
       const state = Array.from({ length: traits.length });
 
+      // Invalidate once per trait even when auto or never skips change detection.
+      if (entities.length !== 0) {
+        for (let i = 0; i < traits.length; i++) {
+          getTraitInstance(ctx.traitInstances, traits[i])!.version++;
+        }
+      }
+
       if (options.changeDetection === 'auto') {
         const changedPairs: [Entity, Trait][] = [];
         const atomicSnapshots: any[] = [];

--- a/packages/core/src/relation/relation.ts
+++ b/packages/core/src/relation/relation.ts
@@ -249,6 +249,7 @@ export function addRelationTarget(
     entityTargets.push(target);
   }
 
+  traitData.version++;
   updateQueriesForRelationChange(ctx, relation, entity);
   addToRelationSources(traitData, entity, target);
 
@@ -300,7 +301,10 @@ export function removeRelationTarget(
     }
   }
 
-  if (removedIndex !== -1) updateQueriesForRelationChange(ctx, relation, entity);
+  if (removedIndex !== -1) {
+    data.version++;
+    updateQueriesForRelationChange(ctx, relation, entity);
+  }
 
   const wasLastTarget = removedIndex !== -1 && !hasRemainingTargets;
   return { removedIndex, wasLastTarget };
@@ -436,6 +440,7 @@ export function setRelationDataAtIndex(
   const baseTrait = relationCtx.trait;
   const traitData = getTraitInstance(ctx.traitInstances, baseTrait);
   if (!traitData) return;
+  traitData.version++;
 
   const store = traitData.store;
   const eid = getEntityId(entity);

--- a/packages/core/src/trait/trait.ts
+++ b/packages/core/src/trait/trait.ts
@@ -95,6 +95,7 @@ export function registerTrait(ctx: WorldContext, trait: Trait) {
   const traitCtx = trait[$internal];
 
   const data: TraitInstance = {
+    version: 0,
     generationId: ctx.entityMasks.length - 1,
     bitflag: ctx.bitflag,
     trait,
@@ -362,13 +363,15 @@ export function getTrait(ctx: WorldContext, entity: Entity, trait: Trait | Relat
   triggerChanged: boolean
 ) {
   const traitCtx = trait[$internal];
-  const store = getStore(ctx, trait);
+  const data = getTraitInstance(ctx.traitInstances, trait)!;
+  const store = data.store;
   const index = getEntityId(entity);
 
   value instanceof Function && (value = value(traitCtx.get(index, store)));
 
   traitCtx.set(index, store, value);
-  triggerChanged && setChanged(ctx, entity, trait);
+  if (triggerChanged) setChanged(ctx, entity, trait);
+  else data.version++;
 }
 
 /* @inline */ function addTraitToEntity(
@@ -387,6 +390,7 @@ export function getTrait(ctx: WorldContext, entity: Entity, trait: Trait | Relat
   const pageId = eid >>> 10;
   const offset = eid & 1023;
   ensureMaskPage(ctx.entityMasks[generationId], pageId)[offset] |= bitflag;
+  instance.version++;
 
   for (const dirtyMask of ctx.dirtyMasks.values()) {
     ensureMaskPage(dirtyMask[generationId], pageId)[offset] |= bitflag;
@@ -427,6 +431,7 @@ function removeTraitFromEntity(ctx: WorldContext, entity: Entity, trait: Trait):
   const pageId = eid >>> 10;
   const offset = eid & 1023;
   ctx.entityMasks[generationId][pageId][offset] &= ~bitflag;
+  instance.version++;
 
   for (const dirtyMask of ctx.dirtyMasks.values()) {
     ensureMaskPage(dirtyMask[generationId], pageId)[offset] |= bitflag;

--- a/packages/core/src/trait/types.ts
+++ b/packages/core/src/trait/types.ts
@@ -75,6 +75,8 @@ export type ExtractIsTag<T extends Trait> = T extends { [$internal]: { type: 'ta
 export type IsTag<T extends Trait> = ExtractIsTag<T>;
 
 export interface TraitInstance<T extends Trait = Trait, S extends Schema = ExtractSchema<T>> {
+  /** Revision for possible writes and membership changes, even without change events. */
+  version: number;
   generationId: number;
   bitflag: number;
   trait: Trait;

--- a/packages/react/src/hooks/use-trait.ts
+++ b/packages/react/src/hooks/use-trait.ts
@@ -1,8 +1,22 @@
-import type { Entity, RelationPair, Trait, TraitRecord, World } from '@koota/core';
+import {
+  $internal,
+  $relationPair,
+  universe,
+  type Entity,
+  type RelationPair,
+  type Trait,
+  type TraitRecord,
+  type World,
+} from '@koota/core';
 import { useEntityValue } from '../utils/use-entity-value';
 
 export function readTrait(entity: Entity, trait: Trait | RelationPair) {
   return entity.has(trait) ? entity.get(trait) : undefined;
+}
+
+function getTraitVersionSource(entity: Entity, trait: Trait | RelationPair) {
+  if ($relationPair in trait) trait = trait.relation[$internal].trait;
+  return universe.pageOwners[entity.id() >>> 10]?.traitInstances[trait.id];
 }
 
 export function attachTrait(
@@ -26,5 +40,6 @@ export function useTrait<T extends Trait>(
   target: Entity | World | undefined | null,
   trait: T | RelationPair<T>
 ): TraitRecord<T> | undefined {
-  return useEntityValue(target, trait, readTrait, attachTrait) as TraitRecord<T> | undefined;
+  return useEntityValue(target, trait, readTrait, attachTrait, getTraitVersionSource) as
+    TraitRecord<T> | undefined;
 }

--- a/packages/react/src/utils/use-entity-value.ts
+++ b/packages/react/src/utils/use-entity-value.ts
@@ -31,22 +31,36 @@ export function sameInput(a: unknown, b: unknown): boolean {
 
 export type Attach<T, I> = (entity: Entity, input: I, push: (value: T) => void) => () => void;
 
-/** The value read from one entity for one input. Mutated in place by the subscription. */
-type Snapshot<T, I> = { entity: Entity | undefined; input: I; value: T | undefined };
+type VersionSource = { version: number };
+type GetVersionSource<I> = (entity: Entity, input: I) => VersionSource | undefined;
 
-function snapshot<T, I>(
+/** Live cache for one entity and input, stable for the subscription lifetime. */
+type Binding<T, I> = {
+  entity: Entity | undefined;
+  input: I;
+  value: T | undefined;
+  version: number;
+  versionSource: VersionSource | undefined;
+};
+
+type State<T, I> = { binding: Binding<T, I> };
+type Action<T, I> = Binding<T, I> | { replace: Binding<T, I> };
+
+function createBinding<T, I>(
   entity: Entity | undefined,
   input: I,
-  read: (entity: Entity, input: I) => T
-): Snapshot<T, I> {
-  return { entity, input, value: entity === undefined ? undefined : read(entity, input) };
+  read: (entity: Entity, input: I) => T,
+  getVersionSource?: GetVersionSource<I>
+): Binding<T, I> {
+  const value = entity === undefined ? undefined : read(entity, input);
+  const versionSource = entity === undefined ? undefined : getVersionSource?.(entity, input);
+  return { entity, input, value, version: versionSource?.version ?? 0, versionSource };
 }
 
-/** State wraps the snapshot so a push re-renders while the snapshot stays the effect key. */
-type State<T, I> = { current: Snapshot<T, I> };
-
-function reducer<T, I>(state: State<T, I>, next: State<T, I> | null): State<T, I> {
-  return next ?? { current: state.current };
+function reducer<T, I>(state: State<T, I>, next: Action<T, I>): State<T, I> {
+  if ('replace' in next) return { binding: next.replace };
+  // A previous subscription may still emit before its effect is cleaned up.
+  return next === state.binding ? { binding: next } : state;
 }
 
 /**
@@ -57,36 +71,51 @@ export function useEntityValue<T, I>(
   target: Entity | World | undefined | null,
   input: I,
   read: (entity: Entity, input: I) => T,
-  attach: Attach<T, I>
+  attach: Attach<T, I>,
+  getVersionSource?: GetVersionSource<I>
 ): T | undefined {
   const entity = resolveEntity(target);
   const [state, dispatch] = useReducer(reducer<T, I>, undefined, () => ({
-    current: snapshot(entity, input, read),
+    binding: createBinding(entity, input, read, getVersionSource),
   }));
 
-  // A new entity or input swaps the snapshot during render so the value is never stale.
-  let current = state.current;
-  if (current.entity !== entity || !sameInput(current.input, input)) {
-    current = snapshot(entity, input, read);
-    dispatch({ current });
+  // Read a new binding during render so a target switch never displays the old value.
+  let binding = state.binding;
+  if (binding.entity !== entity || !sameInput(binding.input, input)) {
+    binding = createBinding(entity, input, read, getVersionSource);
+    dispatch({ replace: binding });
   }
 
+  // Capture what this render used before subscription callbacks can update the cache.
+  const { value, version } = binding;
+
   useEffect(() => {
-    const entity = current.entity;
+    const entity = binding.entity;
     if (entity === undefined) return;
 
     const push = (value: T) => {
-      current.value = value;
-      dispatch(null);
+      binding.value = value;
+      binding.version = binding.versionSource?.version ?? 0;
+      dispatch(binding);
     };
 
-    const detach = attach(entity, current.input, push);
+    const detach = attach(entity, binding.input, push);
     // Catch changes between render and subscribe.
-    const latest = read(entity, current.input);
-    if (!shallowEqual(latest, current.value)) push(latest);
+    if (getVersionSource) {
+      const source = getVersionSource(entity, binding.input);
+      // A reset can replace the source with one at the same version.
+      const replaced = binding.versionSource !== undefined && binding.versionSource !== source;
+      binding.versionSource = source;
+      if (replaced || version !== (source?.version ?? 0)) {
+        push(read(entity, binding.input));
+      }
+    } else {
+      const latest = read(entity, binding.input);
+      if (!shallowEqual(latest, value)) push(latest);
+    }
     return detach;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [current]);
+  }, [binding]);
 
-  return current.value;
+  return value;
 }

--- a/packages/react/tests/trait.test.tsx
+++ b/packages/react/tests/trait.test.tsx
@@ -8,7 +8,7 @@ import {
   type World,
 } from '@koota/core';
 import { render } from '@testing-library/react';
-import { act, StrictMode, useEffect, useState } from 'react';
+import { act, StrictMode, useEffect, useLayoutEffect, useState } from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useHas, useTag, useTrait, useTraitEffect, WorldProvider } from '../src';
 
@@ -285,68 +285,179 @@ describe('useTrait', () => {
     expect(renderCount).toBe(1);
   });
 
-  it('does not spuriously re-render on mount for AoS traits', async () => {
+  it('does not re-render on mount for AoS writes in another world', () => {
     const AoSTrait = trait(() => ({ value: 42 }));
     const entity = world.spawn(AoSTrait);
+    const otherWorld = createWorld();
+    const other = otherWorld.spawn(AoSTrait);
     let renderCount = 0;
 
     function Test() {
       renderCount++;
-      useTrait(entity, AoSTrait);
-      return null;
+      const value = useTrait(entity, AoSTrait);
+      useLayoutEffect(() => other.set(AoSTrait, { value: 10 }), []);
+      return <span>{value?.value}</span>;
     }
 
-    await act(async () => {
-      render(
-        <WorldProvider world={world}>
-          <Test />
-        </WorldProvider>
-      );
-    });
-
+    expect(render(<Test />).container.textContent).toBe('42');
     expect(renderCount).toBe(1);
+    otherWorld.destroy();
   });
 
-  it('immediately reflects the new entity value when switching entities', async () => {
-    const entityA = world.spawn(Position({ x: 1, y: 1 }));
-    const entityB = world.spawn(Position({ x: 99, y: 99 }));
+  it.each([false, true])(
+    'catches an atomic position changed before subscribing with strict mode %s',
+    async (strict) => {
+      const CameraPosition = trait(() => ({ x: 0 }));
+      const entity = world.spawn(CameraPosition);
+      let renders = 0;
+      const tick = () => {
+        world.query(CameraPosition).updateEach(([position]) => {
+          position.x = 10;
+        });
+      };
 
-    let position: TraitRecord<typeof Position> | undefined;
-    const positions: { x: number; y: number }[] = [];
+      function System() {
+        useLayoutEffect(tick, []);
+        return null;
+      }
 
-    function Test({ entity }: { entity: Entity }) {
-      position = useTrait(entity, Position);
-      // Track all position values seen during render
-      if (position) positions.push({ x: position.x, y: position.y });
-      return null;
+      function CameraView() {
+        const position = useTrait(entity, CameraPosition);
+        renders++;
+        return <span>{position?.x}</span>;
+      }
+
+      const scene = (
+        <>
+          <System />
+          <CameraView />
+        </>
+      );
+      const view = render(strict ? <StrictMode>{scene}</StrictMode> : scene);
+
+      expect(entity.get(CameraPosition)!.x).toBe(10);
+      expect(view.container.textContent).toBe('10');
+
+      const initialRenders = renders;
+      await act(async () => tick());
+      expect(view.container.textContent).toBe('10');
+      expect(renders).toBe(initialRenders);
+    }
+  );
+
+  it.each(['set', 'silent set', 'add', 'remove'] as const)(
+    'catches %s before the trait subscription attaches',
+    (operation) => {
+      const Atomic = trait(() => ({ x: 0 }));
+      const entity = operation === 'add' ? world.spawn() : world.spawn(Atomic);
+
+      function View() {
+        const value = useTrait(entity, Atomic);
+        useLayoutEffect(() => {
+          switch (operation) {
+            case 'set':
+              entity.set(Atomic, { x: 10 });
+              break;
+            case 'silent set':
+              entity.set(Atomic, { x: 10 }, false);
+              break;
+            case 'add':
+              entity.add(Atomic({ x: 10 }));
+              break;
+            case 'remove':
+              entity.remove(Atomic);
+              break;
+          }
+        }, []);
+        return <span>{value?.x ?? 'missing'}</span>;
+      }
+
+      const view = render(<View />);
+      expect(view.container.textContent).toBe(operation === 'remove' ? 'missing' : '10');
+    }
+  );
+
+  it('catches a nested mutation signaled before subscribing', () => {
+    const Atomic = trait(() => ({ position: { x: 0 } }));
+    const entity = world.spawn(Atomic);
+
+    function View() {
+      const value = useTrait(entity, Atomic);
+      useLayoutEffect(() => {
+        entity.get(Atomic)!.position.x = 10;
+        entity.changed(Atomic);
+      }, []);
+      return <span>{value?.position.x}</span>;
     }
 
-    const { rerender } = render(
+    expect(render(<View />).container.textContent).toBe('10');
+  });
+
+  it('catches relation pair writes before subscribing', () => {
+    const ChildOf = relation({ store: { order: 0 } });
+    const parent = world.spawn();
+    const child = world.spawn(ChildOf(parent));
+
+    function View() {
+      const value = useTrait(child, ChildOf(parent));
+      useLayoutEffect(() => child.set(ChildOf(parent), { order: 10 }), []);
+      return <span>{value?.order}</span>;
+    }
+
+    expect(render(<View />).container.textContent).toBe('10');
+  });
+
+  it('catches a world trait replaced by reset before subscribing', () => {
+    const Atomic = trait(() => ({ x: 0 }));
+    world.add(Atomic);
+
+    function View() {
+      const value = useTrait(world, Atomic);
+      useLayoutEffect(() => {
+        world.reset();
+        world.add(Atomic({ x: 10 }));
+      }, []);
+      return <span>{value?.x}</span>;
+    }
+
+    expect(render(<View />).container.textContent).toBe('10');
+  });
+
+  it('immediately switches targets and ignores updates from the previous entity', async () => {
+    const previous = world.spawn(Position({ x: 1 }));
+    const next = world.spawn(Position({ x: 99 }));
+    const positions: (number | undefined)[] = [];
+
+    function View({ entity }: { entity: Entity }) {
+      const position = useTrait(entity, Position);
+      positions.push(position?.x);
+      useLayoutEffect(() => {
+        if (entity === next) previous.set(Position, { x: 2 });
+      }, [entity]);
+      return <span>{position?.x}</span>;
+    }
+
+    const view = render(
       <StrictMode>
-        <WorldProvider world={world}>
-          <Test entity={entityA} />
-        </WorldProvider>
+        <View entity={previous} />
       </StrictMode>
     );
+    expect(view.container.textContent).toBe('1');
+    positions.length = 0;
 
-    expect(position).toEqual({ x: 1, y: 1 });
-    positions.length = 0; // Clear initial renders
+    view.rerender(
+      <StrictMode>
+        <View entity={next} />
+      </StrictMode>
+    );
+    expect(view.container.textContent).toBe('99');
+    expect(positions.every((x) => x === 99)).toBe(true);
 
-    // Switch to entity B
     await act(async () => {
-      rerender(
-        <StrictMode>
-          <WorldProvider world={world}>
-            <Test entity={entityB} />
-          </WorldProvider>
-        </StrictMode>
-      );
+      next.set(Position, { x: 100 });
+      previous.set(Position, { x: 3 });
     });
-
-    // Should immediately have entity B's value, never see entity A's stale value
-    expect(position).toEqual({ x: 99, y: 99 });
-    // Every render after the switch should show entity B's value
-    expect(positions.every((p) => p.x === 99 && p.y === 99)).toBe(true);
+    expect(view.container.textContent).toBe('100');
   });
 
   it('reactively returns relation pair store data', async () => {


### PR DESCRIPTION
`useTrait` could leave its initial render stale when an object trait was mutated between render and subscription. The hook now catches that missed write immediately after subscribing, in both normal and Strict Mode.

A version counter was added to a `TraitInstance` like we have on `QueryInstance` and acts as a cheap way for a framework to know if the trait it is tracked has updated between checks.